### PR TITLE
[feat] Dockerfile 에서 끌어오는 image version 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: custom JRE 생성 (jlink 활용)
-FROM amd64/amazoncorretto:21-alpine-jdk AS builder-jre
+FROM amazoncorretto:21-alpine-jdk AS builder-jre
 RUN apk add --no-cache binutils
 RUN $JAVA_HOME/bin/jlink \
     --module-path "$JAVA_HOME/jmods" \
@@ -10,8 +10,9 @@ RUN $JAVA_HOME/bin/jlink \
     --output /custom-jre
 
 # Stage 2: 애플리케이션 jar 파일 준비
-FROM amd64/amazoncorretto:21-alpine-jdk AS builder
+FROM amazoncorretto:21-alpine-jdk AS builder
 ARG SERVICE_NAME
+RUN echo ${SERVICE_NAME}
 WORKDIR /app
 COPY ${SERVICE_NAME}/build/libs/*.jar app.jar
 ENV SPRING_PROFILES_ACTIVE=dev


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#82

👷 **작업한 내용**
기존 docker-compose 를 통해 컨테이너 이미지를 끌어오던중 docker-hub 에 저장된 이미지 일부가 끌어와지지 않는 이슈를 겪었습니다.
이에 해당 컨테이너는 로컬 환경에서 이미지를 생성할 수 있도록  Dockerfile 을 수정했습니다.

docker-compose 수정사항은 docker-compose 노션 페이지 맨 하단에 기입해두었습니다.

## 🚨 참고 사항
노션에 정의된 docker-compose 를 통해 이미지를 생성하던중 몇가지 파일이 공유되지 않음을 확인했습니다. 확인 부탁드립니다!
- redis.conf, pg_hba.conf

## 📟 관련 이슈
- Resolved: #82 

기존 Dockerfile 을 통해 이미지를 생성하던 중 아래 라인에서 에러가 발생했습니다.

`FROM amd64/amazoncorretto:21-alpine-jdk AS builder-jre`
<img width="1411" alt="image" src="https://github.com/user-attachments/assets/f28b108d-a2c1-4c32-b1d0-471c1331e62c" />
`amd64/amazoncorretto:21-alpine-jdk` 를 불러오기 위해 `amazoncorretto:21-alpine-jdk` 로 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- 베이스 이미지 설정을 개선하여 아키텍처 접두사 제거.
	- 빌드 과정에서 서비스 이름이 출력되도록 로깅 기능 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->