### PR TITLE
[fix] cluster -> single redis - #109

### DIFF
--- a/chat-service/src/main/java/org/kiru/chat/config/redis/RedisStreamSubscriber.java
+++ b/chat-service/src/main/java/org/kiru/chat/config/redis/RedisStreamSubscriber.java
@@ -33,7 +33,7 @@ public class RedisStreamSubscriber {
     private final EurekaInstanceConfig eurekaInstanceConfig;
     private final MessageEventListener messageEventListener;
     private final RedisTemplate<String, String> redisTemplateForOne;
-    private final RedisConnectionFactory redisConnectionFactoryForCluster;
+    private final RedisConnectionFactory redisConnectionFactory;
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
     private StreamMessageListenerContainer<String, MapRecord<String, String, String>> messageListenerContainer;
@@ -90,7 +90,7 @@ public class RedisStreamSubscriber {
                 }).build();
 
         StreamMessageListenerContainer<String, MapRecord<String, String, String>> container =
-                StreamMessageListenerContainer.create(redisConnectionFactoryForCluster, containerOptions);
+                StreamMessageListenerContainer.create(redisConnectionFactory, containerOptions);
 
         container.register(
                 StreamMessageListenerContainer.StreamReadRequest.builder(

--- a/chat-service/src/main/java/org/kiru/chat/config/redis/RedisStreamSubscriber.java
+++ b/chat-service/src/main/java/org/kiru/chat/config/redis/RedisStreamSubscriber.java
@@ -33,7 +33,7 @@ public class RedisStreamSubscriber {
     private final EurekaInstanceConfig eurekaInstanceConfig;
     private final MessageEventListener messageEventListener;
     private final RedisTemplate<String, String> redisTemplateForOne;
-    private final RedisConnectionFactory redisConnectionFactory;
+    private final RedisConnectionFactory redisConnectionFactoryForOne;
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
     private StreamMessageListenerContainer<String, MapRecord<String, String, String>> messageListenerContainer;
@@ -90,7 +90,7 @@ public class RedisStreamSubscriber {
                 }).build();
 
         StreamMessageListenerContainer<String, MapRecord<String, String, String>> container =
-                StreamMessageListenerContainer.create(redisConnectionFactory, containerOptions);
+                StreamMessageListenerContainer.create(redisConnectionFactoryForOne, containerOptions);
 
         container.register(
                 StreamMessageListenerContainer.StreamReadRequest.builder(


### PR DESCRIPTION
## 🔥*Pull requests*

### PR확인해주시고 머지하셔도 됩니다! 

⛳️ **작업한 브랜치**
- fix/#109

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- cluster -> single NODE로 변경 

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 이문제였을줄은 몰랐는데 클러스터를 스트림에 등록해주고 있었네요...
- 클러스터를 현재 사용중이지 않으니 싱글노드를 등록해줘야해요!
- 지난 서비스에서 클러스터를 썼었는데..사실 문제의 근본적인 원인은 다음과 같아요! 
 1. 레디스 스트림을 메시지큐로 활용할 경우 구독을 끊지 않고 사용할경우 
 ```
  container.register(
                StreamMessageListenerContainer.StreamReadRequest.builder(
                                StreamOffset.create(streamKey, ReadOffset.lastConsumed()))
                        .cancelOnError(t -> true) // 오류 발생 시 구독 취소
                        .consumer(Consumer.from(consumerGroup, consumerName))
                        .autoAcknowledge(false)
                        .build(), eventListener);
```
다음 부분에서 cancelOnError를 false로 하면 이미 오류난 연결을 무한히 재시도하여 메모리 누수가 발생하고 지속적으로 레디스에 연결하려고 시도해 시스템 과부하가 발생해요! 
따라서 해당 옵션을 오류 발생시 구독취소하게 만들고 커스텀으로 fallback 로직을 만들어야 해요
```
    private void restartSubscription(String streamKey, String consumerGroup, String consumerName,
                                     StreamListener<String, MapRecord<String, String, String>> eventListener) {
        scheduler.schedule(() -> {
            log.info("Restarting subscription for stream: {}", streamKey);
            stopContainer(streamKey);
            createStreamSubscription(streamKey, consumerGroup, consumerName, eventListener).start();
        }, 5, TimeUnit.SECONDS); // 일정 시간 후 재시작
```

그리고 해당 fallback로직을 해당 에러가 발생하는 에러핸들러로 추가하면 재구독을 실행시키는 방식으로 동작시킬수 있어요

```
        StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> containerOptions = StreamMessageListenerContainerOptions
                .builder()
                .pollTimeout(Duration.ofSeconds(1L))
                .errorHandler(e -> {
                    log.error("Error in listener: {}", e.getMessage());
                    restartSubscription(streamKey, consumerGroup, consumerName, eventListener);
                }).build();
```

즉 정리하자면 
1. 네트워크이슈나 다른 이슈발생시 레디스 구독을 끊어야 하며, 끊지 않을시 메모리 누수와 시스템 과부하가 일어날 수 있어요
2. 구독을 끊고 재구독하는 로직을 에러핸들러로 추가해요! 
3. 구독을 하는 서비스는 @PreDestroy로 누수를 방지하고 재생성해요


## 📟 관련 이슈
- Resolved: #109 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **리팩터**
	- 내부 식별자의 명칭을 개선하여 코드의 가독성과 유지보수성을 향상시켰습니다. 기능 자체에는 변화가 없으며, 변경된 이름을 통해 일관성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->