### PR TITLE
[FEAT] email 중복 error 코드 전송

### DIFF
--- a/core/src/main/java/org/kiru/core/exception/code/FailureCode.java
+++ b/core/src/main/java/org/kiru/core/exception/code/FailureCode.java
@@ -86,6 +86,7 @@ public enum FailureCode {
     CONFLICT(HttpStatus.CONFLICT, "e4090", "이미 존재하는 리소스입니다."),
     DUPLICATE_USER(HttpStatus.CONFLICT, "e4091", "이미 존재하는 유저입니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "e4092", "이미 존재하는 닉네임입니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "e4093", "이미 존재하는 이메일입니다."),
 
     /**
      * 500 Internal Server Error

--- a/user-service/src/main/java/org/kiru/user/auth/mail/controller/MailController.java
+++ b/user-service/src/main/java/org/kiru/user/auth/mail/controller/MailController.java
@@ -2,13 +2,10 @@ package org.kiru.user.auth.mail.controller;
 
 import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
-import org.kiru.core.exception.ConflictException;
-import org.kiru.core.exception.code.FailureCode;
 import org.kiru.user.auth.mail.dto.MailCheckDto;
 import org.kiru.user.auth.mail.dto.MailCheckResponse;
 import org.kiru.user.auth.mail.dto.MailSendDto;
 import org.kiru.user.auth.mail.service.MailService;
-import org.kiru.user.user.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/user-service/src/main/java/org/kiru/user/auth/mail/controller/MailController.java
+++ b/user-service/src/main/java/org/kiru/user/auth/mail/controller/MailController.java
@@ -2,10 +2,13 @@ package org.kiru.user.auth.mail.controller;
 
 import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
+import org.kiru.core.exception.ConflictException;
+import org.kiru.core.exception.code.FailureCode;
 import org.kiru.user.auth.mail.dto.MailCheckDto;
 import org.kiru.user.auth.mail.dto.MailCheckResponse;
 import org.kiru.user.auth.mail.dto.MailSendDto;
 import org.kiru.user.auth.mail.service.MailService;
+import org.kiru.user.user.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/user-service/src/main/java/org/kiru/user/auth/mail/service/MailService.java
+++ b/user-service/src/main/java/org/kiru/user/auth/mail/service/MailService.java
@@ -5,7 +5,10 @@ import jakarta.mail.internet.MimeMessage;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.kiru.core.exception.ConflictException;
+import org.kiru.core.exception.code.FailureCode;
 import org.kiru.user.auth.mail.dto.MailCheckDto;
+import org.kiru.user.user.service.UserService;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -16,6 +19,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MailService {
     private final JavaMailSender javaMailSender;
+    private final UserService userService;
     private final RedisTemplate<String, String> redisTemplateForOne ;
     private static final String senderEmail = "rlarlgnszx0319@gmail.com";
 
@@ -42,8 +46,15 @@ public class MailService {
         return message;
     }
 
+    private void validateEmailNotExists(String email) {
+        if (userService.existsByEmail(email)) {
+            throw new ConflictException(FailureCode.DUPLICATE_EMAIL);
+        }
+    }
+
     // 메일 발송
     public String sendSimpleMessage(String sendEmail) throws MessagingException {
+        validateEmailNotExists(sendEmail);
         String number = createNumber(); // 랜덤 인증번호 생성
         MimeMessage message = createMail(sendEmail, number); // 메일 생성
         try {

--- a/user-service/src/main/java/org/kiru/user/user/controller/UserController.java
+++ b/user-service/src/main/java/org/kiru/user/user/controller/UserController.java
@@ -15,7 +15,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;

--- a/user-service/src/main/java/org/kiru/user/user/repository/UserRepository.java
+++ b/user-service/src/main/java/org/kiru/user/user/repository/UserRepository.java
@@ -57,6 +57,4 @@ public interface UserRepository extends JpaRepository<UserJpaEntity,Long> {
             "INNER JOIN UserPortfolioImg p ON u.id = p.userId " +
             "WHERE p.sequence = 1 AND u.username LIKE %:name% ")
     Slice<UserDto> findSimpleUserByName(String name, Pageable pageable);
-
-    boolean existsByEmail(String email);
 }

--- a/user-service/src/main/java/org/kiru/user/user/service/UserService.java
+++ b/user-service/src/main/java/org/kiru/user/user/service/UserService.java
@@ -190,4 +190,8 @@ public class UserService implements GetUserMainPageUseCase {
     public void deleteUser(Long userId) {
         userRepository.deleteById(userId);
     }
+
+    public boolean existsByEmail(String email) {
+        return userRepository.findByEmail(email).isPresent();
+    }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#113
👷 **작업한 내용**
회원가입 시 중복된 이메일을 입력할 경우 적절한 예외 처리를 적용

✅ 변경 사항
1.	이메일 중복 시 409 Conflict 에러 코드 반환

- 	FailureCode.DUPLICATE_EMAIL 사용하여 예외 처리

2.	이메일 중복 확인을 위한 validateEmailNotExists 메서드 생성

- 	MailService에서 직접 UserService를 호출하던 방식을 개선
- 	중복 확인 로직을 별도 메서드로 분리하여 재사용성과 가독성 증가

3.	유저 서비스에서 findByEmail을 사용하여 중복 검사

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 이메일 중복 확인 기능이 강화되어, 등록된 이메일 사용 시 "이미 존재하는 이메일입니다."라는 명확한 오류 메시지를 통해 중복 등록을 방지합니다.
  - 사용자 관리 측면에서 이메일 존재 여부를 더욱 신속하게 확인할 수 있도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->