### PR TITLE
[FIX] MessageList 페이지네이션 반영 - #129

### DIFF
--- a/chat-service/src/main/java/org/kiru/chat/adapter/in/web/ChatRoomController.java
+++ b/chat-service/src/main/java/org/kiru/chat/adapter/in/web/ChatRoomController.java
@@ -58,7 +58,7 @@ public class ChatRoomController {
     }
 
     @GetMapping("/rooms/{roomId}/messages")
-    public List<Message> getMessageByRoomId(@PathVariable Long roomId, @UserId Long userId,
+    public PageableResponse<Message> getMessageByRoomId(@PathVariable Long roomId, @UserId Long userId,
                                              @RequestParam Boolean admin, Pageable pageable) {
         return getMessageUseCase.getMessages(roomId, userId, admin, pageable);
     }

--- a/chat-service/src/main/java/org/kiru/chat/adapter/out/persistence/MessageRepository.java
+++ b/chat-service/src/main/java/org/kiru/chat/adapter/out/persistence/MessageRepository.java
@@ -16,13 +16,14 @@ public interface MessageRepository extends JpaRepository<MessageJpaEntity, Long>
     List<MessageJpaEntity> findAllByChatRoomIdOrderByCreatedAt(Long chatRoomId);
 
     List<MessageJpaEntity> findAllByChatRoomIdAndReadStatusFalse(Long chatRoomId);
+
     @QueryHints(value = {
             @QueryHint(name = "org.hibernate.readOnly", value = "true"),
             @QueryHint(name = "org.hibernate.fetchSize", value = "150"),
             @QueryHint(name = "jakarta.persistence.query.timeout", value = "5000")
 
     })
-    Slice<MessageJpaEntity> findAllByChatRoomIdOrderByCreatedAtAscIdAsc(Long chatRoomId, Pageable pageable);
+    Slice<MessageJpaEntity> findAllByChatRoomId(Long chatRoomId, Pageable pageable);
 
     @Query(value = "SELECT m as message,mt as translateMessage FROM MessageJpaEntity m "
             + "LEFT JOIN TranslateMessageJpaEntity mt "

--- a/chat-service/src/main/java/org/kiru/chat/application/port/in/GetMessageUseCase.java
+++ b/chat-service/src/main/java/org/kiru/chat/application/port/in/GetMessageUseCase.java
@@ -2,8 +2,9 @@ package org.kiru.chat.application.port.in;
 
 import java.util.List;
 import org.kiru.core.chat.message.domain.Message;
+import org.kiru.core.common.PageableResponse;
 import org.springframework.data.domain.Pageable;
 
 public interface GetMessageUseCase {
-    List<Message> getMessages(Long roomId, Long userId, Boolean isAdmin,Pageable pageable);
+    PageableResponse<Message> getMessages(Long roomId, Long userId, Boolean isAdmin, Pageable pageable);
 }

--- a/chat-service/src/main/java/org/kiru/chat/application/port/out/GetMessageByRoomQuery.java
+++ b/chat-service/src/main/java/org/kiru/chat/application/port/out/GetMessageByRoomQuery.java
@@ -2,10 +2,11 @@ package org.kiru.chat.application.port.out;
 
 import java.util.List;
 import org.kiru.core.chat.message.domain.Message;
+import org.kiru.core.common.PageableResponse;
 import org.springframework.data.domain.Pageable;
 
 public interface GetMessageByRoomQuery {
     List<Message> findAllByChatRoomIdWithMessageToRead(Long chatRoomId, Long userId, Boolean isUserAdmin);
 
-    List<Message> getMessages(Long roomId, Long userId, Boolean isUserAdmin, Pageable pageable);
+    PageableResponse<Message> getMessages(Long roomId, Long userId, Boolean isUserAdmin, Pageable pageable);
 }

--- a/chat-service/src/main/java/org/kiru/chat/application/service/ChatService.java
+++ b/chat-service/src/main/java/org/kiru/chat/application/service/ChatService.java
@@ -83,7 +83,7 @@ public class ChatService implements CreateRoomUseCase, GetChatRoomUseCase , AddP
     }
 
     @Override
-    public List<Message> getMessages(Long roomId, Long userId, Boolean isUserAdmin,Pageable pageable) {
+    public PageableResponse<Message> getMessages(Long roomId, Long userId, Boolean isUserAdmin,Pageable pageable) {
         return getMessageByRoomQuery.getMessages(roomId, userId,isUserAdmin, pageable);
     }
 }

--- a/user-service/src/main/java/org/kiru/user/admin/controller/AdminController.java
+++ b/user-service/src/main/java/org/kiru/user/admin/controller/AdminController.java
@@ -83,8 +83,8 @@ public class AdminController {
     }
 
     @GetMapping("/rooms/{roomId}/messages")
-    public ResponseEntity<List<Message>> getMessages(@PathVariable Long roomId, @UserId Long userId, Pageable pageable) {
-        List<Message> messages = adminService.getMessages(roomId, userId, true, pageable);
+    public ResponseEntity<PageableResponse<Message>> getMessages(@PathVariable Long roomId, @UserId Long userId, Pageable pageable) {
+        PageableResponse<Message> messages = adminService.getMessages(roomId, userId, true, pageable);
         return ResponseEntity.ok(messages);
     }
 }

--- a/user-service/src/main/java/org/kiru/user/admin/service/AdminService.java
+++ b/user-service/src/main/java/org/kiru/user/admin/service/AdminService.java
@@ -10,6 +10,7 @@ import java.util.concurrent.Executors;
 import lombok.RequiredArgsConstructor;
 import org.kiru.core.chat.chatroom.domain.ChatRoom;
 import org.kiru.core.chat.message.domain.Message;
+import org.kiru.core.common.PageableResponse;
 import org.kiru.user.admin.dto.AdminLikeUserResponse;
 import org.kiru.user.admin.dto.AdminLikeUserResponse.AdminLikeUserDto;
 import org.kiru.user.admin.dto.AdminMatchedUserResponse;
@@ -96,7 +97,7 @@ public class AdminService {
         }
     }
 
-    public List<Message> getMessages(Long roomId, Long userId, Boolean isAdmin, Pageable pageable) {
+    public PageableResponse<Message> getMessages(Long roomId, Long userId, Boolean isAdmin, Pageable pageable) {
         return chatApiClient.getMessages(roomId, userId, isAdmin, pageable);
     }
 }

--- a/user-service/src/main/java/org/kiru/user/user/api/ChatApiClient.java
+++ b/user-service/src/main/java/org/kiru/user/user/api/ChatApiClient.java
@@ -45,5 +45,5 @@ public interface ChatApiClient {
     ChatRoom getOrCreateCsChatRoom(@RequestParam Long adminId, @RequestParam Long userId);
 
     @GetMapping("/api/v1/chat/rooms/{roomId}/messages")
-    List<Message> getMessages(@PathVariable Long roomId, @RequestHeader("X-User-Id") Long userId,@RequestParam Boolean admin, @RequestParam Pageable pageable);
+    PageableResponse<Message> getMessages(@PathVariable Long roomId, @RequestHeader("X-User-Id") Long userId,@RequestParam Boolean admin, @RequestParam Pageable pageable);
 }

--- a/user-service/src/main/java/org/kiru/user/user/controller/UserController.java
+++ b/user-service/src/main/java/org/kiru/user/user/controller/UserController.java
@@ -7,6 +7,7 @@ import org.kiru.core.user.user.domain.User;
 import org.kiru.user.auth.argumentresolve.UserId;
 import org.kiru.user.user.dto.response.ChatRoomListResponse;
 import org.kiru.user.user.dto.response.ChatRoomResponse;
+import org.kiru.user.user.dto.response.MessageResponse;
 import org.kiru.user.user.dto.response.UserWithAdditionalInfoResponse;
 import org.kiru.user.user.service.UserService;
 import org.springframework.boot.actuate.autoconfigure.tracing.ConditionalOnEnabledTracing;
@@ -46,8 +47,8 @@ public class UserController {
     }
 
     @GetMapping("/me/chatroom/{roomId}/messages")
-    public ResponseEntity<ChatRoomResponse> getChatMessages(@PathVariable("roomId") Long roomId, @UserId Long userId, Pageable pageable){
-        ChatRoomResponse response = userService.getChatMessage(roomId, userId, pageable.getPageNumber(), pageable.getPageSize());
+    public ResponseEntity<PageableResponse<MessageResponse>> getChatMessages(@PathVariable("roomId") Long roomId, @UserId Long userId, Pageable pageable){
+        PageableResponse<MessageResponse> response = userService.getChatMessage(roomId, userId, pageable);
         return ResponseEntity.ok(response);
     }
 

--- a/user-service/src/main/java/org/kiru/user/user/dto/response/ChatRoomResponse.java
+++ b/user-service/src/main/java/org/kiru/user/user/dto/response/ChatRoomResponse.java
@@ -40,14 +40,4 @@ public class ChatRoomResponse {
                 .chatRoomThumbnail(chatRoom.getChatRoomThumbnail())
                 .build();
     }
-
-    public static ChatRoomResponse of(ChatRoom chatRoom, List<MessageResponse> messages){
-        return ChatRoomResponse.builder()
-            .id(chatRoom.getId())
-            .title(chatRoom.getTitle())
-            .messages(messages)
-            .participants(chatRoom.getParticipants())
-            .chatRoomThumbnail(chatRoom.getChatRoomThumbnail())
-            .build();
-    }
 }

--- a/user-service/src/main/java/org/kiru/user/user/service/UserService.java
+++ b/user-service/src/main/java/org/kiru/user/user/service/UserService.java
@@ -8,6 +8,7 @@ import java.util.concurrent.Executors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.kiru.core.chat.chatroom.domain.ChatRoom;
+import org.kiru.core.chat.message.domain.Message;
 import org.kiru.core.common.PageableResponse;
 import org.kiru.core.exception.EntityNotFoundException;
 import org.kiru.core.exception.code.FailureCode;
@@ -21,7 +22,6 @@ import org.kiru.user.portfolio.service.out.GetUserPortfoliosQuery;
 import org.kiru.user.user.api.ChatApiClient;
 import org.kiru.user.user.dto.request.UserUpdateDto;
 import org.kiru.user.user.dto.request.UserUpdatePwdDto;
-import org.kiru.user.user.dto.response.ChatRoomResponse;
 import org.kiru.user.user.dto.response.MessageResponse;
 import org.kiru.user.user.repository.UserRepository;
 import org.kiru.user.user.service.in.GetUserMainPageUseCase;
@@ -30,9 +30,7 @@ import org.kiru.user.user.service.out.UserQueryWithCache;
 import org.kiru.user.user.service.out.UserUpdatePort;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -73,35 +71,28 @@ public class UserService implements GetUserMainPageUseCase {
         }
     }
 
-    public ChatRoomResponse getChatMessage(Long roomId, Long userId, int page, int size) {
+    public PageableResponse<MessageResponse> getChatMessage(Long roomId, Long userId, Pageable pageable) {
         try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
-        CompletableFuture<ChatRoom> chatRoomFuture = CompletableFuture.supplyAsync(
-                () -> chatApiClient.getRoom(roomId, userId), executor);
-        CompletableFuture<List<UserPortfolioItem>> userPortfolioImgMapFuture = chatRoomFuture.thenApplyAsync(
-                ChatRoom::getParticipantsIds, executor).thenApplyAsync(
-                getUserPortfoliosQuery::getUserPortfoliosWithMinSequence, executor);
-        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
-        CompletableFuture<List<MessageResponse>> messageFuture = CompletableFuture.supplyAsync(
-                () -> chatApiClient.getMessages(roomId, userId, false, pageable)
-                .stream().map(MessageResponse::fromMessage).toList(), executor);
-        return chatRoomFuture.thenCombineAsync(userPortfolioImgMapFuture,
-                (chatRoom, userPortfolioImgMap) -> {
-                    chatRoom.setThumbnailAndRoomTitle(userPortfolioImgMap.getFirst());
-                    return chatRoom;
-                }, executor).thenCombineAsync(messageFuture, ChatRoomResponse::of, executor).join();
+            return CompletableFuture.supplyAsync(() -> {
+                PageableResponse<Message> messageResponse = chatApiClient.getMessages(roomId, userId, false, pageable);
+                List<MessageResponse> messageResponseList = messageResponse.getContent()
+                        .stream().map(MessageResponse::fromMessage).toList();
+                return PageableResponse.of(messageResponse, messageResponseList);
+            }, executor).join();
         }
     }
+
     public ChatRoom getUserChatRoom(Long roomId, Long userId) {
         try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
-        CompletableFuture<ChatRoom> chatRoomFuture = CompletableFuture.supplyAsync(
-                () -> chatApiClient.getRoom(roomId, userId), executor);
-        CompletableFuture<List<UserPortfolioItem>> userPortfolioImgMapFuture = chatRoomFuture.thenApplyAsync(
-                ChatRoom::getParticipantsIds, executor).thenApplyAsync(
-                getUserPortfoliosQuery::getUserPortfoliosWithMinSequence, executor);
-        return chatRoomFuture.thenCombineAsync(userPortfolioImgMapFuture,
-                (chatRoom, userPortfolioImgMap) -> {
-                    chatRoom.setThumbnailAndRoomTitle(userPortfolioImgMap.getFirst());
-                    return chatRoom;}, executor).join();
+            CompletableFuture<ChatRoom> chatRoomFuture = CompletableFuture.supplyAsync(
+                    () -> chatApiClient.getRoom(roomId, userId), executor);
+            CompletableFuture<List<UserPortfolioItem>> userPortfolioImgMapFuture = chatRoomFuture.thenApplyAsync(
+                    ChatRoom::getParticipantsIds, executor).thenApplyAsync(
+                    getUserPortfoliosQuery::getUserPortfoliosWithMinSequence, executor);
+            return chatRoomFuture.thenCombineAsync(userPortfolioImgMapFuture,
+                    (chatRoom, userPortfolioImgMap) -> {
+                        chatRoom.setThumbnailAndRoomTitle(userPortfolioImgMap.getFirst());
+                        return chatRoom;}, executor).join();
         }
     }
 


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#129

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

#127 에서의 구현 로직과 동일하게 Slice를 사용해서 hasNext 값을 가져왔습니다.

기존의 getRoom() api는 메시지 뿐만 아니라 채팅룸의 정보를 불필요하게 보내주고 있어 메시지 리스트만 반환하는 getMessageByRoomId() api를 추가했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 채팅 메시지 조회 시, 페이징 처리된 응답을 제공하여 총 페이지 수 및 항목 정보를 함께 확인할 수 있게 되었습니다.
  
- **리팩토링**
  - 채팅 및 사용자 관련 서비스 전반에 걸쳐 메시지 데이터 처리 방식이 통일되어, 일관되고 효율적인 메시지 전달이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->