### PR TITLE
[FEAT] 회원가입 시 포트폴리오 이미지 업로드 요청 비동기처리 적용

### DIFF
--- a/user-service/src/main/java/org/kiru/user/user/service/AuthService.java
+++ b/user-service/src/main/java/org/kiru/user/user/service/AuthService.java
@@ -3,7 +3,6 @@ package org.kiru.user.user.service;
 import java.util.Date;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.kiru.core.exception.EntityNotFoundException;
 import org.kiru.core.exception.InvalidValueException;
 import org.kiru.core.exception.UnauthorizedException;
@@ -32,123 +31,124 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
-@Slf4j
 public class AuthService {
-    private final UserRepository userRepository;
-    private final JwtProvider jwtProvider;
-    private final RefreshTokenRepository refreshTokenRepository;
-    private final ApplicationEventPublisher applicationEventPublisher;
-    private final PasswordEncoder passwordEncoder;
 
-    // 회원가입
-    @Transactional
-    public UserJwtInfoRes signUp(UserSignUpReq userSignUpReq, List<MultipartFile> images,
-                                 List<UserPurposesReq> purposes, List<UserTalentsReq> talents) {
-        User.UserBuilder newUserBuilder = User.builder()
-                .description(userSignUpReq.description())
-                .email(userSignUpReq.email())
-                .instagramId(userSignUpReq.instagramId())
-                .loginType(userSignUpReq.loginType())
-                .username(userSignUpReq.name())
-                .socialId(userSignUpReq.socialId())
-                .webUrl(userSignUpReq.webUrl());
-        if (userSignUpReq.loginType() == LoginType.LOCAL) {
-            newUserBuilder.password(encodePassword(userSignUpReq.password()));
-        }
-        User newUser = newUserBuilder.build();
-        UserJpaEntity user = userRepository.save(UserJpaEntity.of(newUser));
-        Date now = new Date();
-        Token issuedToken = jwtProvider.issueToken(user.getId(), user.getEmail(),now);
-        applicationEventPublisher.publishEvent(
-            UserCreateEvent.builder()
-                .userName(user.getUsername())
-                .userId(user.getId())
-                .images(images)
-                .purposes(purposes)
-                .talents(talents)
-                .build()
-        );
-        return UserJwtInfoRes.of(user.getId(), issuedToken.accessToken(), issuedToken.refreshToken());
+  private final UserRepository userRepository;
+  private final JwtProvider jwtProvider;
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final ApplicationEventPublisher applicationEventPublisher;
+  private final PasswordEncoder passwordEncoder;
+
+  // 회원가입
+  @Transactional
+  public UserJwtInfoRes signUp(UserSignUpReq userSignUpReq, List<MultipartFile> images,
+      List<UserPurposesReq> purposes, List<UserTalentsReq> talents) {
+    User.UserBuilder newUserBuilder = User.builder()
+        .description(userSignUpReq.description())
+        .email(userSignUpReq.email())
+        .instagramId(userSignUpReq.instagramId())
+        .loginType(userSignUpReq.loginType())
+        .username(userSignUpReq.name())
+        .socialId(userSignUpReq.socialId())
+        .webUrl(userSignUpReq.webUrl());
+    if (userSignUpReq.loginType() == LoginType.LOCAL) {
+      newUserBuilder.password(encodePassword(userSignUpReq.password()));
     }
+    User newUser = newUserBuilder.build();
+    UserJpaEntity user = userRepository.save(UserJpaEntity.of(newUser));
+    Date now = new Date();
+    Token issuedToken = jwtProvider.issueToken(user.getId(), user.getEmail(), now);
+    applicationEventPublisher.publishEvent(
+        UserCreateEvent.builder()
+            .userName(user.getUsername())
+            .userId(user.getId())
+            .images(images)
+            .purposes(purposes)
+            .talents(talents)
+            .build()
+    );
+    return UserJwtInfoRes.of(user.getId(), issuedToken.accessToken(), issuedToken.refreshToken());
+  }
 
-    // 로그인
-    @Transactional
-    public UserJwtInfoRes signIn(final UserSignInReq userSignInReq) {
-        Date now = new Date();
-        return userRepository.findByEmail(userSignInReq.email())
-                .filter(user -> checkPassword(userSignInReq.password(), user.getPassword()))
-                .map(user -> {
-                    refreshTokenRepository.deleteByUserId(user.getId());
-                    Token issuedToken = jwtProvider.issueToken(user.getId(), user.getEmail(),now);
-                    return UserJwtInfoRes.of(user.getId(), issuedToken.accessToken(), issuedToken.refreshToken());
-                })
-                .orElseThrow(() -> new UnauthorizedException(FailureCode.INVALID_USER_CREDENTIALS));
+  // 로그인
+  @Transactional
+  public UserJwtInfoRes signIn(final UserSignInReq userSignInReq) {
+    Date now = new Date();
+    return userRepository.findByEmail(userSignInReq.email())
+        .filter(user -> checkPassword(userSignInReq.password(), user.getPassword()))
+        .map(user -> {
+          refreshTokenRepository.deleteByUserId(user.getId());
+          Token issuedToken = jwtProvider.issueToken(user.getId(), user.getEmail(), now);
+          return UserJwtInfoRes.of(user.getId(), issuedToken.accessToken(),
+              issuedToken.refreshToken());
+        })
+        .orElseThrow(() -> new UnauthorizedException(FailureCode.INVALID_USER_CREDENTIALS));
+  }
+
+  @Transactional
+  public UserJwtInfoRes reissue(final Long userId) {
+    Date now = new Date();
+    UserJpaEntity user = userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException(FailureCode.USER_NOT_FOUND));
+    refreshTokenRepository.deleteRefreshTokenByUserId(userId);
+    Token newToken = jwtProvider.issueToken(userId, user.getEmail(), now);
+    return UserJwtInfoRes.of(userId, newToken.accessToken(), newToken.refreshToken());
+  }
+
+  private String encodePassword(String rawPassword) {
+    return passwordEncoder.encode(rawPassword);
+  }
+
+  // 비밀번호 비교 로직
+  public boolean checkPassword(String rawPassword, String encodedPassword) {
+    if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
+      throw new UnauthorizedException(FailureCode.PASSWORD_MISMATCH);
     }
+    return true;
+  }
 
-    @Transactional
-    public UserJwtInfoRes reissue(final Long userId) {
-        Date now = new Date();
-        UserJpaEntity user = userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException(FailureCode.USER_NOT_FOUND));
-        refreshTokenRepository.deleteRefreshTokenByUserId(userId);
-        Token newToken = jwtProvider.issueToken(userId, user.getEmail(),now);
-        return UserJwtInfoRes.of(userId, newToken.accessToken(), newToken.refreshToken());
+  public SignHelpDtoRes signHelp(SignHelpDto signHelpDto) {
+    String email = userRepository.findByUsername(signHelpDto.userName())
+        .orElseThrow(() -> new EntityNotFoundException(FailureCode.USER_NOT_FOUND));
+    try {
+      String maskedEmail = maskEmail(email);
+      return new SignHelpDtoRes(maskedEmail);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidValueException(FailureCode.INVALID_EMAIL_FORMAT);
     }
+  }
 
-    private String encodePassword(String rawPassword) {
-        return passwordEncoder.encode(rawPassword);
+  private String maskEmail(String email) {
+    int atIndex = email.indexOf("@");
+    if (atIndex == -1 || atIndex == 0) {
+      throw new IllegalArgumentException("Invalid email address");
     }
-
-    // 비밀번호 비교 로직
-    public boolean checkPassword(String rawPassword, String encodedPassword) {
-        if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
-            throw new UnauthorizedException(FailureCode.PASSWORD_MISMATCH);
-        }
-        return true;
+    String localPart = email.substring(0, atIndex);
+    StringBuilder maskedLocalPart = new StringBuilder();
+    int localLength = localPart.length();
+    if (localLength <= 2) {
+      maskedLocalPart.append(localPart.charAt(0)).append("*");
+    } else {
+      maskedLocalPart.append(localPart.charAt(0))
+          .append(localPart.charAt(1))
+          .append("*".repeat(localLength - 4))
+          .append(localPart.charAt(localLength - 2))
+          .append(localPart.charAt(localLength - 1));
     }
+    String domainPart = email.substring(atIndex + 1);
+    String[] domainParts = domainPart.split("\\.");
+    StringBuilder maskedDomainPart = new StringBuilder();
 
-    public SignHelpDtoRes signHelp(SignHelpDto signHelpDto) {
-        String email = userRepository.findByUsername(signHelpDto.userName())
-                .orElseThrow(() -> new EntityNotFoundException(FailureCode.USER_NOT_FOUND));
-        try {
-            String maskedEmail = maskEmail(email);
-            return new SignHelpDtoRes(maskedEmail);
-        } catch (IllegalArgumentException e) {
-            throw new InvalidValueException(FailureCode.INVALID_EMAIL_FORMAT);
-        }
+    if (domainParts.length >= 2) {
+      String domainName = domainParts[0];
+      maskedDomainPart.append(domainName.charAt(0)) // 첫 글자 표시
+          .append("*".repeat(domainName.length() - 2)) // 중간 글자 마스킹
+          .append(domainName.charAt(domainName.length() - 1))
+          .append(".");
+      maskedDomainPart.append("***");
+    } else {
+      throw new IllegalArgumentException("Invalid domain format");
     }
-
-    private String maskEmail(String email) {
-        int atIndex = email.indexOf("@");
-        if (atIndex == -1 || atIndex == 0) {
-            throw new IllegalArgumentException("Invalid email address");
-        }
-        String localPart = email.substring(0, atIndex);
-        StringBuilder maskedLocalPart = new StringBuilder();
-        int localLength = localPart.length();
-        if (localLength <= 2) {
-            maskedLocalPart.append(localPart.charAt(0)).append("*");
-        } else {
-            maskedLocalPart.append(localPart.charAt(0))
-                    .append(localPart.charAt(1))
-                    .append("*".repeat(localLength - 4))
-                    .append(localPart.charAt(localLength - 2))
-                    .append(localPart.charAt(localLength - 1));
-        }
-        String domainPart = email.substring(atIndex + 1);
-        String[] domainParts = domainPart.split("\\.");
-        StringBuilder maskedDomainPart = new StringBuilder();
-
-        if (domainParts.length >= 2) {
-            String domainName = domainParts[0];
-            maskedDomainPart.append(domainName.charAt(0)) // 첫 글자 표시
-                    .append("*".repeat(domainName.length() - 2)) // 중간 글자 마스킹
-                    .append(domainName.charAt(domainName.length() - 1))
-                    .append(".");
-            maskedDomainPart.append("***");
-        } else {
-            throw new IllegalArgumentException("Invalid domain format");
-        }
-        return maskedLocalPart + "@" + maskedDomainPart;
-    }
+    return maskedLocalPart + "@" + maskedDomainPart;
+  }
 }

--- a/user-service/src/main/java/org/kiru/user/user/service/AuthService.java
+++ b/user-service/src/main/java/org/kiru/user/user/service/AuthService.java
@@ -2,10 +2,6 @@ package org.kiru.user.user.service;
 
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.kiru.core.exception.EntityNotFoundException;
@@ -27,14 +23,9 @@ import org.kiru.user.user.dto.request.UserTalentsReq;
 import org.kiru.user.user.dto.response.SignHelpDtoRes;
 import org.kiru.user.user.dto.response.UserJwtInfoRes;
 import org.kiru.user.user.repository.UserRepository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -48,7 +39,6 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final PasswordEncoder passwordEncoder;
-
 
     // 회원가입
     @Transactional
@@ -69,15 +59,15 @@ public class AuthService {
         UserJpaEntity user = userRepository.save(UserJpaEntity.of(newUser));
         Date now = new Date();
         Token issuedToken = jwtProvider.issueToken(user.getId(), user.getEmail(),now);
-
-        UserCreateEvent userCreateEvent = UserCreateEvent.builder()
-            .userName(user.getUsername())
-            .userId(user.getId())
-            .images(images)
-            .purposes(purposes)
-            .talents(talents)
-            .build();
-        applicationEventPublisher.publishEvent(userCreateEvent);
+        applicationEventPublisher.publishEvent(
+            UserCreateEvent.builder()
+                .userName(user.getUsername())
+                .userId(user.getId())
+                .images(images)
+                .purposes(purposes)
+                .talents(talents)
+                .build()
+        );
         return UserJwtInfoRes.of(user.getId(), issuedToken.accessToken(), issuedToken.refreshToken());
     }
 


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#132

👷 **작업한 내용**
기존의 업로드를 담당하던 org.kiru.user.user.event.UserPortfolioEventService.class 에 비동기 처리를 위해 CompletableFuture 를 사용했습니다.

## 🚨 참고 사항
리팩토링 후 회원가입 중복 요청에 대한 처리 예정

## 📟 관련 이슈
- Resolved: #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 이미지 저장 시 비동기 처리를 도입하여 업로드 및 저장 작업의 응답성을 향상시켰습니다. 이를 통해 사용자 인터페이스의 반응 속도가 개선되어 보다 원활한 이용 경험을 제공합니다.
  
- **Style**
  - `AuthService` 클래스의 코드 포맷팅 및 구조를 개선하여 가독성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->