### PR TITLE
[Feat] 회원가입 중 이메일 인증 비동기 처리 적용 #136

### DIFF
--- a/user-service/src/main/java/org/kiru/user/auth/mail/async/AsyncMailSender.java
+++ b/user-service/src/main/java/org/kiru/user/auth/mail/async/AsyncMailSender.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -21,6 +22,7 @@ public class AsyncMailSender {
   private final JavaMailSender javaMailSender;
   private static ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
 
+  @Async
   public void sendMail(MimeMessage message, String number) throws MessagingException {
     String received = message.getRecipients(MimeMessage.RecipientType.TO)[0].toString();
 

--- a/user-service/src/main/java/org/kiru/user/auth/mail/async/AsyncMailSender.java
+++ b/user-service/src/main/java/org/kiru/user/auth/mail/async/AsyncMailSender.java
@@ -1,0 +1,39 @@
+package org.kiru.user.auth.mail.async;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AsyncMailSender {
+
+  private final RedisTemplate<String, String> redisTemplateForOne;
+  private final JavaMailSender javaMailSender;
+  private static ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+
+  public void sendMail(MimeMessage message, String number) throws MessagingException {
+    String received = message.getRecipients(MimeMessage.RecipientType.TO)[0].toString();
+
+    try {
+      CompletableFuture.runAsync(() -> {
+        javaMailSender.send(message);
+      }, executor);
+      CompletableFuture.runAsync(() -> {
+        redisTemplateForOne.opsForValue().set(received, number);
+      }, executor);
+    } catch (MailException e) {
+      log.error(e.getMessage());
+      throw new IllegalArgumentException("메일 발송 중 오류가 발생했습니다.");
+    }
+  }
+}

--- a/user-service/src/main/java/org/kiru/user/auth/mail/async/AsyncMailSender.java
+++ b/user-service/src/main/java/org/kiru/user/auth/mail/async/AsyncMailSender.java
@@ -24,22 +24,18 @@ public class AsyncMailSender {
   @Async
   public void sendMail(MimeMessage message, String number) throws MessagingException {
     String received = message.getRecipients(MimeMessage.RecipientType.TO)[0].toString();
-    CompletableFuture<Void> sendMailFuture = CompletableFuture.runAsync(() -> {
-      try {
-        javaMailSender.send(message);
-      } catch (MailException e) {
-        log.error("Error sending mail: {}", e.getMessage(), e);
-        throw e;
-      }
-    }, executor);
+    try {
+      javaMailSender.send(message);
+    } catch (MailException e) {
+      log.error("Error sending mail: {}", e.getMessage(), e);
+      throw e;
+    }
 
-    CompletableFuture<Void> cacheFuture = CompletableFuture.runAsync(() -> {
-      try {
-        redisTemplateForOne.opsForValue().set(received, number);
-      } catch (Exception e) {
-        log.error("Error caching mail data: {}", e.getMessage(), e);
-        throw e;
-      }
-    }, executor);
+    try {
+      redisTemplateForOne.opsForValue().set(received, number);
+    } catch (Exception e) {
+      log.error("Error caching mail data: {}", e.getMessage(), e);
+      throw e;
+    }
   }
 }

--- a/user-service/src/main/java/org/kiru/user/auth/mail/async/AsyncMailSender.java
+++ b/user-service/src/main/java/org/kiru/user/auth/mail/async/AsyncMailSender.java
@@ -3,8 +3,7 @@ package org.kiru.user.auth.mail.async;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.Executor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -20,7 +19,7 @@ public class AsyncMailSender {
 
   private final RedisTemplate<String, String> redisTemplateForOne;
   private final JavaMailSender javaMailSender;
-  private static ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+  private final Executor executor;
 
   @Async
   public void sendMail(MimeMessage message, String number) throws MessagingException {

--- a/user-service/src/main/java/org/kiru/user/auth/mail/controller/MailController.java
+++ b/user-service/src/main/java/org/kiru/user/auth/mail/controller/MailController.java
@@ -20,8 +20,8 @@ public class MailController {
     private final MailService mailService;
 
     @PostMapping("/emailsend")
-    public String emailCheck(@RequestBody MailSendDto mailSendDTO) throws MessagingException {
-        return mailService.sendSimpleMessage(mailSendDTO.getEmail()); // Response body에 값을 반환
+    public void emailCheck(@RequestBody MailSendDto mailSendDTO) throws MessagingException {
+        mailService.sendSimpleMessage(mailSendDTO.getEmail());
     }
 
     @PostMapping("/emailcheck")

--- a/user-service/src/main/java/org/kiru/user/auth/mail/service/MailService.java
+++ b/user-service/src/main/java/org/kiru/user/auth/mail/service/MailService.java
@@ -3,6 +3,8 @@ package org.kiru.user.auth.mail.service;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.kiru.core.exception.ConflictException;
@@ -18,65 +20,69 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @RequiredArgsConstructor
 public class MailService {
-    private final JavaMailSender javaMailSender;
-    private final UserService userService;
-    private final RedisTemplate<String, String> redisTemplateForOne ;
-    private static final String senderEmail = "rlarlgnszx0319@gmail.com";
 
-    // 랜덤으로 6자리 숫자 생성
-    public String createNumber() {
-        Random random = new Random();
-        StringBuilder key = new StringBuilder();
-        for (int i = 0; i < 6; i++) {
-            key.append(random.nextInt(10));
-        }
-        return key.toString();
+  private final JavaMailSender javaMailSender;
+  private final UserService userService;
+  private final RedisTemplate<String, String> redisTemplateForOne;
+  private static final String senderEmail = "rlarlgnszx0319@gmail.com";
+
+  // 랜덤으로 6자리 숫자 생성
+  public String createNumber() {
+    Random random = new Random();
+    StringBuilder key = new StringBuilder();
+    for (int i = 0; i < 6; i++) {
+      key.append(random.nextInt(10));
     }
+    return key.toString();
+  }
 
-    public MimeMessage createMail(String mail, String number) throws MessagingException {
-        MimeMessage message = javaMailSender.createMimeMessage();
-        message.setFrom(senderEmail);
-        message.setRecipients(MimeMessage.RecipientType.TO, mail);
-        message.setSubject("이메일 인증");
-        String body = "";
-        body += "<h3>요청하신 인증 번호입니다.</h3>";
-        body += "<h1>" + number + "</h1>";
-        body += "<h3>감사합니다.</h3>";
-        message.setText(body, "UTF-8", "html");
-        return message;
+  public MimeMessage createMail(String mail, String number) throws MessagingException {
+    MimeMessage message = javaMailSender.createMimeMessage();
+    message.setFrom(senderEmail);
+    message.setRecipients(MimeMessage.RecipientType.TO, mail);
+    message.setSubject("이메일 인증");
+    String body = "";
+    body += "<h3>요청하신 인증 번호입니다.</h3>";
+    body += "<h1>" + number + "</h1>";
+    body += "<h3>감사합니다.</h3>";
+    message.setText(body, "UTF-8", "html");
+    return message;
+  }
+
+  private void validateEmailNotExists(String email) {
+    if (userService.existsByEmail(email)) {
+      throw new ConflictException(FailureCode.DUPLICATE_EMAIL);
     }
+  }
 
-    private void validateEmailNotExists(String email) {
-        if (userService.existsByEmail(email)) {
-            throw new ConflictException(FailureCode.DUPLICATE_EMAIL);
-        }
-    }
+  // 메일 발송
+  public void sendSimpleMessage(String sendEmail) throws MessagingException {
+    validateEmailNotExists(sendEmail);
+    String number = createNumber(); // 랜덤 인증번호 생성
+    sendMail(sendEmail, number);
+  }
 
-    // 메일 발송
-    public void sendSimpleMessage(String sendEmail) throws MessagingException {
-        validateEmailNotExists(sendEmail);
-        String number = createNumber(); // 랜덤 인증번호 생성
-        sendMail(sendEmail, number);
-    }
+  private void sendMail(String sendEmail, String number) throws MessagingException {
+    MimeMessage message = createMail(sendEmail, number); // 메일 생성
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      CompletableFuture.runAsync(() -> {
+        javaMailSender.send(message);
+      }, executor);
 
-    private void sendMail(String sendEmail, String number) throws MessagingException{
-        MimeMessage message = createMail(sendEmail, number); // 메일 생성
-
-        try {
-            javaMailSender.send(message); // 메일 발송
+      CompletableFuture.runAsync(() -> {
             redisTemplateForOne.opsForValue().set(sendEmail, number);
-        } catch (MailException e) {
-            log.error(e.getMessage());
-            throw new IllegalArgumentException("메일 발송 중 오류가 발생했습니다.");
-        }
+          }, executor);
+    } catch (MailException e) {
+      log.error(e.getMessage());
+      throw new IllegalArgumentException("메일 발송 중 오류가 발생했습니다.");
     }
+  }
 
-    public Boolean checkMessage(MailCheckDto mailCheckDto) {
-        String savedNumber = redisTemplateForOne.opsForValue().get(mailCheckDto.getEmail());
-        if (savedNumber != null && savedNumber.equals(mailCheckDto.getAuthCode())) {
-            return true;
-        }
-        return false;
+  public Boolean checkMessage(MailCheckDto mailCheckDto) {
+    String savedNumber = redisTemplateForOne.opsForValue().get(mailCheckDto.getEmail());
+    if (savedNumber != null && savedNumber.equals(mailCheckDto.getAuthCode())) {
+      return true;
     }
-
+    return false;
+  }
 }

--- a/user-service/src/main/java/org/kiru/user/auth/mail/service/MailService.java
+++ b/user-service/src/main/java/org/kiru/user/auth/mail/service/MailService.java
@@ -53,10 +53,15 @@ public class MailService {
     }
 
     // 메일 발송
-    public String sendSimpleMessage(String sendEmail) throws MessagingException {
+    public void sendSimpleMessage(String sendEmail) throws MessagingException {
         validateEmailNotExists(sendEmail);
         String number = createNumber(); // 랜덤 인증번호 생성
+        sendMail(sendEmail, number);
+    }
+
+    private void sendMail(String sendEmail, String number) throws MessagingException{
         MimeMessage message = createMail(sendEmail, number); // 메일 생성
+
         try {
             javaMailSender.send(message); // 메일 발송
             redisTemplateForOne.opsForValue().set(sendEmail, number);
@@ -64,7 +69,6 @@ public class MailService {
             log.error(e.getMessage());
             throw new IllegalArgumentException("메일 발송 중 오류가 발생했습니다.");
         }
-        return number;
     }
 
     public Boolean checkMessage(MailCheckDto mailCheckDto) {


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#136

👷 **작업한 내용**

**문제 상황:**
    - 메일 인증 기능 개발 중, 기존 동기 방식에서 프론트의 대기 시간이 길어지는 문제 발견
    - 이를 해결하기 위해 비동기 처리를 적용했지만, 초기 구현에서는 포스트맨 테스트 시 약 5.96s 응답 시간
**초기 코드 접근:**
    - 메일 전송과 캐시에 인증번호 저장 작업을 `CompletableFuture.runAsync()`를 이용하여 병렬로 실행하도록 구현
    - 매번 새로운 executor를 생성하여 실행한 후 종료하는 방식으로 처리
    - 포스트맨 테스트시 약 3.66s 응답 시간
**Async 어노테이션 적용**
    - 메서드 전체가 별도의 스레드에서 실행하도록 하여 제어권 반환
    - 클라이언트 응답시간 612ms 로 단축

## 🚨 참고 사항
swift 에서 해당 api 로 응답 받고 별다른 처리를 안하는 것 같아서 해당 api 반환값을 기존 String 에서 void 로 바꿨습니다.

## 📟 관련 이슈
- Resolved: #136 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - 이메일 인증 및 전송 프로세스가 간소화되어 메일 발송이 더욱 신속하고 안정적으로 개선되었습니다.
  - 비동기 처리 방식의 업데이트로 이메일 작업의 응답성과 신뢰성이 향상되었습니다.
  - 이메일 발송 로직이 새로운 비동기 메일 발송 클래스를 통해 관리되도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->