### PR TITLE
fix [#144] 본인 프로필 조회 시 response body 에 국적 정보 추가

### DIFF
--- a/user-service/src/main/java/org/kiru/user/user/dto/response/UserWithAdditionalInfoResponse.java
+++ b/user-service/src/main/java/org/kiru/user/user/dto/response/UserWithAdditionalInfoResponse.java
@@ -2,6 +2,7 @@ package org.kiru.user.user.dto.response;
 
 import java.util.List;
 import org.kiru.core.user.talent.entity.UserTalent;
+import org.kiru.core.user.user.domain.Nationality;
 import org.kiru.core.user.user.domain.User;
 import org.kiru.core.user.userPortfolioItem.domain.UserPortfolio;
 import org.kiru.core.user.userPortfolioItem.domain.UserPortfolioItem;
@@ -14,6 +15,7 @@ public record UserWithAdditionalInfoResponse(
         String description,
         String instagramId,
         String webUrl,
+        Nationality nationality,
         UserPortfolioResponse userPortfolio,
         List<Integer> userPurposes,
         List<UserTalent> userTalents
@@ -26,6 +28,7 @@ public record UserWithAdditionalInfoResponse(
                 user.getDescription(),
                 user.getInstagramId(),
                 user.getWebUrl(),
+                user.getNationality(),
                 UserPortfolioResponse.of(user.getUserPortfolio()),
                 user.getUserPurposes(),
                 user.getUserTalents().stream().map(


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#144

👷 **작업한 내용**
UserWithAdditionalInfoResponse 객체에 nationality 필드 추가

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #144 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 사용자 프로필에 국적 정보가 추가되어, 보다 풍부한 사용자 정보를 제공하게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->