### PR TITLE
fix: 회원가입 중 포트폴리오 이미지 업로드 실패 - #157

### DIFF
--- a/user-service/src/main/java/org/kiru/user/external/s3/ImageService.java
+++ b/user-service/src/main/java/org/kiru/user/external/s3/ImageService.java
@@ -3,7 +3,6 @@ package org.kiru.user.external.s3;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;

--- a/user-service/src/main/java/org/kiru/user/user/event/UserPortfolioEventService.java
+++ b/user-service/src/main/java/org/kiru/user/user/event/UserPortfolioEventService.java
@@ -1,10 +1,8 @@
 package org.kiru.user.user.event;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.kiru.user.external.s3.ImageService;
 import org.kiru.user.user.dto.event.UserCreateEvent;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,7 +13,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class UserPortfolioEventService {
     private final ImageService imageService;
 
-    @Async
     @TransactionalEventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void userPortfolioCreate(UserCreateEvent userCreateEvent){


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#157

👷 **작업한 내용**
회원가입 시 event 생성 시 객체를 저장하는 방식으로 동작하던 UserPortfolioEventService 가 Async 와 함께 동작
- 내부에서 호출한 ImageService 클래스의 내부에서는 비동기 방식으로 동작
- Async 호출로 인해 내부로 전달된 MultipartFile 은 임시 데이터로 UserPortfolioEventService 의 생명주기와 함께 소멸
- 그 후 s3 는 빈 객체를 저장하려 시도하며 에러 발생

이전에 문제가 되지 않았던 이유는 Asyncable 어노테이션이 없었기 때문인 것으로 보입니다. 최근 포트폴리오 수정 api 를 작업하면서 해당 어노테이션이 추가되었고 Async 어노테이션이 제 기능을 할 수 있게 되면서 발생한 헤프닝...

## 🚨 참고 사항

## 📟 관련 이슈
- Resolved: #157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터**
  - 불필요한 의존성 제거를 통해 코드 기반이 간소화되었습니다.
  - 사용자 포트폴리오 이벤트 처리 방식이 개선되어, 트랜잭션 내에서 동기적으로 실행됨으로써 안정성과 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->