### PR TITLE
Feat [#172] 이메일 인증 시 인증 목적 전달받도록

### DIFF
--- a/user-service/src/main/java/org/kiru/user/auth/mail/controller/MailController.java
+++ b/user-service/src/main/java/org/kiru/user/auth/mail/controller/MailController.java
@@ -21,7 +21,7 @@ public class MailController {
 
     @PostMapping("/emailsend")
     public void emailCheck(@RequestBody MailSendDto mailSendDTO) throws MessagingException {
-        mailService.sendSimpleMessage(mailSendDTO.getEmail());
+        mailService.sendSimpleMessage(mailSendDTO);
     }
 
     @PostMapping("/emailcheck")

--- a/user-service/src/main/java/org/kiru/user/auth/mail/dto/MailSendDto.java
+++ b/user-service/src/main/java/org/kiru/user/auth/mail/dto/MailSendDto.java
@@ -3,10 +3,12 @@ package org.kiru.user.auth.mail.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.kiru.user.auth.mail.enums.EmailSendPurpose;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class MailSendDto {
     private String email;
+    private EmailSendPurpose purpose;
 }

--- a/user-service/src/main/java/org/kiru/user/auth/mail/enums/EmailSendPurpose.java
+++ b/user-service/src/main/java/org/kiru/user/auth/mail/enums/EmailSendPurpose.java
@@ -1,0 +1,5 @@
+package org.kiru.user.auth.mail.enums;
+
+public enum EmailSendPurpose {
+  SIGNUP, RESET
+}

--- a/user-service/src/main/java/org/kiru/user/auth/mail/service/MailService.java
+++ b/user-service/src/main/java/org/kiru/user/auth/mail/service/MailService.java
@@ -9,6 +9,8 @@ import org.kiru.core.exception.ConflictException;
 import org.kiru.core.exception.code.FailureCode;
 import org.kiru.user.auth.mail.async.AsyncMailSender;
 import org.kiru.user.auth.mail.dto.MailCheckDto;
+import org.kiru.user.auth.mail.dto.MailSendDto;
+import org.kiru.user.auth.mail.enums.EmailSendPurpose;
 import org.kiru.user.user.service.UserService;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -55,10 +57,13 @@ public class MailService {
   }
 
   // 메일 발송
-  public void sendSimpleMessage(String sendEmail) throws MessagingException {
-    validateEmailNotExists(sendEmail);
+  public void sendSimpleMessage(MailSendDto sendEmail) throws MessagingException {
+    String address = sendEmail.getEmail();
+    if(sendEmail.getPurpose() == EmailSendPurpose.SIGNUP){
+      validateEmailNotExists(address);
+    }
     String number = createNumber(); // 랜덤 인증번호 생성
-    MimeMessage message = createMail(sendEmail, number);
+    MimeMessage message = createMail(address, number);
     asyncMailSender.sendMail(message, number);
   }
 


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#172

👷 **작업한 내용**
이메일 인증 목적
1. 회원가입 -> 기존에 존재하는 이메일이 있는지 확인 후 이메일 인증 문자 전송
2. 비밀번호 찾기 -> 기존에 존재하는 이메일이 있는지 확인 않고 인증 문자 전송
- 이메일 있는지 먼저 확인한 뒤에 인증 문자 전송하는 로직 추가하자

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #172 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 이메일 전송 기능이 개선되어, 전송 요청 시 추가 정보를 활용할 수 있게 되었습니다.
  - 사용자 가입 및 비밀번호 재설정 등 상황에 맞춰 이메일 처리 로직이 강화되어, 중복 이메일 확인 등의 보안 검증이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->