### PR TITLE
[FIX] unreadMessageCount 정상 반영되도록 수정 

### DIFF
--- a/chat-service/src/main/java/org/kiru/chat/adapter/in/web/WebSocketHandler.java
+++ b/chat-service/src/main/java/org/kiru/chat/adapter/in/web/WebSocketHandler.java
@@ -34,9 +34,12 @@ public class WebSocketHandler {
     public Message sendMessage(@DestinationVariable @Validated Long roomId, @Validated @Payload Message message) {
         ofNullable(message).orElseThrow(() -> new IllegalArgumentException("Message must be provided"));
         ofNullable(message.getSendedId()).orElseThrow(() -> new IllegalArgumentException("Receiver(Sended) ID must be provided"));
+        
         Long receiverId = message.getSendedId();
+        Long senderId = message.getSenderId();
         message.chatRoom(roomId);
         
+<<<<<<< Updated upstream
         // 1. 상대방이 접속 중인지 확인
         boolean isUserConnected = webSocketUserService.isUserConnected(receiverId.toString());
         
@@ -53,5 +56,19 @@ public class WebSocketHandler {
         chatNotificationService.sendNotification(message);
         
         return savedMessage;
+=======
+        // 자신에게 보낸 메시지이거나 자신이 보낸 메시지는 읽음 처리
+        if (senderId != null && senderId.equals(receiverId)) {
+            message.toRead();
+        }
+        
+        // 상대방 연결 여부 확인 (읽음 처리와는 무관, 단지 메시지 전송 방식 결정을 위함)
+        boolean isUserConnected = webSocketUserService.isUserConnected(receiverId.toString());
+        if (isUserConnected) {
+            return sendMessageUseCase.sendMessage(roomId, message);
+        } else {
+            return saveMessageUseCase.saveMessage(roomId, message);
+        }
+>>>>>>> Stashed changes
     }
 }

--- a/chat-service/src/main/java/org/kiru/chat/adapter/in/web/WebSocketHandler.java
+++ b/chat-service/src/main/java/org/kiru/chat/adapter/in/web/WebSocketHandler.java
@@ -32,43 +32,32 @@ public class WebSocketHandler {
 
     @MessageMapping("/chat.send/{roomId}")
     public Message sendMessage(@DestinationVariable @Validated Long roomId, @Validated @Payload Message message) {
+        // 유효성 검사
         ofNullable(message).orElseThrow(() -> new IllegalArgumentException("Message must be provided"));
         ofNullable(message.getSendedId()).orElseThrow(() -> new IllegalArgumentException("Receiver(Sended) ID must be provided"));
         
+        // 채팅방 설정
         Long receiverId = message.getSendedId();
         Long senderId = message.getSenderId();
         message.chatRoom(roomId);
         
-<<<<<<< Updated upstream
-        // 1. 상대방이 접속 중인지 확인
-        boolean isUserConnected = webSocketUserService.isUserConnected(receiverId.toString());
-        
-        // 2. 상대방이 접속중이면 읽음 처리 후 메시지 전송
-        if(isUserConnected) {
-            message.toRead();
-            return sendMessageUseCase.sendMessage(roomId, message);
-        }
-        
-        // 3. 메시지 저장
-        Message savedMessage = saveMessageUseCase.saveMessage(roomId, message);
-        
-        // 4. 푸시 알림 전송
-        chatNotificationService.sendNotification(message);
-        
-        return savedMessage;
-=======
-        // 자신에게 보낸 메시지이거나 자신이 보낸 메시지는 읽음 처리
-        if (senderId != null && senderId.equals(receiverId)) {
+        // 본인이 보낸 메시지는 항상 읽음 처리
+        if (senderId != null) {
             message.toRead();
         }
         
-        // 상대방 연결 여부 확인 (읽음 처리와는 무관, 단지 메시지 전송 방식 결정을 위함)
-        boolean isUserConnected = webSocketUserService.isUserConnected(receiverId.toString());
-        if (isUserConnected) {
+        // 수신자가 접속 중인지 확인
+        boolean isReceiverConnected = webSocketUserService.isUserConnected(receiverId.toString());
+        
+        // 메시지 처리 및 알림
+        if (isReceiverConnected) {
+            // 수신자가 접속 중이면 메시지 전송
             return sendMessageUseCase.sendMessage(roomId, message);
         } else {
-            return saveMessageUseCase.saveMessage(roomId, message);
+            // 수신자가 접속 중이 아니면 메시지 저장 후 푸시 알림
+            Message savedMessage = saveMessageUseCase.saveMessage(roomId, message);
+            chatNotificationService.sendNotification(message);
+            return savedMessage;
         }
->>>>>>> Stashed changes
     }
 }

--- a/chat-service/src/main/java/org/kiru/chat/adapter/out/persistence/MessageRepository.java
+++ b/chat-service/src/main/java/org/kiru/chat/adapter/out/persistence/MessageRepository.java
@@ -7,9 +7,11 @@ import org.kiru.core.chat.message.entity.MessageJpaEntity;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface MessageRepository extends JpaRepository<MessageJpaEntity, Long> {
@@ -30,4 +32,14 @@ public interface MessageRepository extends JpaRepository<MessageJpaEntity, Long>
             + "ON m.id = mt.messageId "
             + "WHERE m.id IN :messageIds")
     List<MessageWithTranslationDto> findAllByMessageIds(List<Long> messageIds);
+
+    List<MessageJpaEntity> findAllByChatRoomIdAndReadStatusFalseAndSenderIdNot(Long chatRoomId, Long userId);
+
+    @Query("SELECT COUNT(m) FROM MessageJpaEntity m WHERE m.chatRoomId = :chatRoomId AND m.readStatus = false AND m.senderId <> :userId")
+    int countUnreadMessagesByChatRoomIdAndUserId(Long chatRoomId, Long userId);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE MessageJpaEntity m SET m.readStatus = true WHERE m.chatRoomId = :chatRoomId AND m.readStatus = false AND m.senderId <> :userId")
+    int markMessagesAsRead(Long chatRoomId, Long userId);
 }

--- a/chat-service/src/main/java/org/kiru/chat/adapter/out/persistence/MessageRepositoryAdapter.java
+++ b/chat-service/src/main/java/org/kiru/chat/adapter/out/persistence/MessageRepositoryAdapter.java
@@ -31,9 +31,7 @@ public class MessageRepositoryAdapter implements SaveMessagePort , GetMessageByR
     public List<Message> findAllByChatRoomIdWithMessageToRead(Long chatRoomId, Long userId, Boolean isUserAdmin) {
         return messageRepository.findAllByChatRoomIdOrderByCreatedAt(chatRoomId).stream()
                 .map(messageJpaEntity -> {
-                    if (!messageJpaEntity.getSenderId().equals(userId) & isUserAdmin.equals(false)) {
-                        messageJpaEntity.setReadStatus(true);
-                    }
+                    // 읽음 처리하지 않고 그대로 반환
                     return MessageJpaEntity.toModel(messageJpaEntity);
                 }).toList();
     }
@@ -42,9 +40,7 @@ public class MessageRepositoryAdapter implements SaveMessagePort , GetMessageByR
     public PageableResponse<Message> getMessages(Long roomId, Long userId, Boolean isUserAdmin, Pageable pageable) {
         Slice<MessageJpaEntity> messageSlice = messageRepository.findAllByChatRoomId(roomId, pageable);
         List<Message> messages = messageSlice.getContent().stream().parallel().map(messageJpaEntity -> {
-                    if (!messageJpaEntity.getSenderId().equals(userId) && !isUserAdmin) {
-                        messageJpaEntity.setReadStatus(true);
-                    }
+                    // 읽음 처리하지 않고 그대로 반환
                     return MessageJpaEntity.toModel(messageJpaEntity);
                 })
                 .toList();

--- a/chat-service/src/main/java/org/kiru/chat/adapter/out/persistence/UserJoinChatRoomRepository.java
+++ b/chat-service/src/main/java/org/kiru/chat/adapter/out/persistence/UserJoinChatRoomRepository.java
@@ -17,7 +17,7 @@ public interface UserJoinChatRoomRepository extends JpaRepository<UserJoinChatRo
     List<Long> findOtherParticipantIds(Long chatRoomId, Long senderId);
 
     @Query("SELECT cr as chatRoom, " +
-            "COUNT(CASE WHEN m.readStatus = false AND m.senderId <> :userId THEN m.id END)/2 AS unreadMessageCount, " +
+            "COUNT(CASE WHEN m.readStatus = false AND m.senderId <> :userId THEN m.id END) AS unreadMessageCount, " +
             "(SELECT m1.content"
             + "        FROM MessageJpaEntity m1"
             + "        WHERE m1.chatRoomId = cr.id"

--- a/chat-service/src/main/java/org/kiru/chat/application/service/WebSocketUserService.java
+++ b/chat-service/src/main/java/org/kiru/chat/application/service/WebSocketUserService.java
@@ -70,4 +70,16 @@ public class WebSocketUserService {
         }
         return null;
     }
+    
+    // 사용자가 특정 채팅방에 접속 중인지 확인하는 메서드
+    // 현재는 단순히 접속 여부만 확인하지만, 추후 특정 채팅방 구독 상태까지 확인하도록 확장 가능
+    public boolean isUserInChatRoom(final String userId, final Long chatRoomId) {
+        // 일단 사용자가 접속 중인지만 확인
+        return isUserConnected(userId);
+        
+        // 추후 개선: Redis에 사용자별 현재 활성화된 채팅방 정보를 저장하여 확인
+        // String activeRoomKey = "user:" + userId + ":active_room";
+        // String activeRoomId = redisTemplateForOne.opsForValue().get(activeRoomKey);
+        // return chatRoomId.toString().equals(activeRoomId);
+    }
 }

--- a/chat-service/src/main/java/org/kiru/chat/event/MessageReadStatusService.java
+++ b/chat-service/src/main/java/org/kiru/chat/event/MessageReadStatusService.java
@@ -1,6 +1,8 @@
 package org.kiru.chat.event;
 
 import java.util.List;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.kiru.chat.adapter.out.persistence.MessageRepository;
 import org.kiru.core.chat.message.entity.MessageJpaEntity;
@@ -11,13 +13,25 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MessageReadStatusService {
     private final MessageRepository messageRepository;
+    
+    @PersistenceContext
+    private EntityManager entityManager;
 
+    /**
+     * 특정 채팅방의 메시지를 읽음 처리합니다.
+     * 이 메서드는 명시적으로 호출될 때만 메시지를 읽음 처리합니다.
+     */
     @Transactional
     public void markAllMessagesAsRead(Long chatRoomId, Long userId) {
-        List<MessageJpaEntity> messages = messageRepository.findAllByChatRoomIdAndReadStatusFalse(chatRoomId);
-        for (MessageJpaEntity message : messages) {
-            message.setReadStatus(true);
-            messageRepository.save(message);
-        }
+        // @Modifying 쿼리를 사용하여 직접 업데이트 - 캐시 문제를 방지
+        int updatedCount = messageRepository.markMessagesAsRead(chatRoomId, userId);
+    }
+    
+    /**
+     * 채팅방의 안 읽은 메시지 수를 반환합니다.
+     * 이 메서드는 메시지의 읽음 상태를 변경하지 않고 단순히 조회만 합니다.
+     */
+    public int getUnreadMessageCount(Long chatRoomId, Long userId) {
+        return messageRepository.countUnreadMessagesByChatRoomIdAndUserId(chatRoomId, userId);
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- fix/#190

👷 **작업한 내용**
unreadMessageCount 정상 반영

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
  - 채팅방에서 메시지 읽음 상태가 자동으로 업데이트되어 미확인 메시지 개수가 정확하게 표시됩니다.
  - 자기 자신에게 보낸 메시지가 자동으로 읽음 처리되어 사용자 경험이 개선되었습니다.
  - 실시간 채팅 알림과 채팅방 요약 정보가 향상되었습니다.
  - 채팅방 참여 여부를 확인하는 새로운 기능이 추가되었습니다.
  - 각 채팅방에 대한 미확인 메시지 개수를 조회할 수 있는 기능이 추가되었습니다.

- **버그 수정**
  - 미확인 메시지 개수 계산 방식의 문제를 해결해 정확도를 높였습니다.
  - 메시지 읽음 처리 로직을 최적화해 일관성과 효율성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->