### PR TITLE
fix [#194] unreadMessageCount 제대로 보이도록 수정

### DIFF
--- a/chat-service/src/main/java/org/kiru/chat/adapter/in/web/WebSocketHandler.java
+++ b/chat-service/src/main/java/org/kiru/chat/adapter/in/web/WebSocketHandler.java
@@ -41,8 +41,14 @@ public class WebSocketHandler {
         Long senderId = message.getSenderId();
         message.chatRoom(roomId);
         
-        // 본인이 보낸 메시지는 항상 읽음 처리
-        if (senderId != null) {
+        // 기본적으로 메시지는 읽지 않음 상태로 설정
+        message.setReadStatus(false);
+        
+        // 수신자가 같은 채팅방에 접속 중인지 확인
+        boolean isReceiverInRoom = webSocketUserService.isUserInChatRoom(receiverId.toString(), roomId);
+        
+        // 수신자가 같은 채팅방에 있으면 읽음 처리
+        if (isReceiverInRoom) {
             message.toRead();
         }
         

--- a/chat-service/src/main/java/org/kiru/chat/adapter/out/persistence/ChatRoomRepositoryAdapter.java
+++ b/chat-service/src/main/java/org/kiru/chat/adapter/out/persistence/ChatRoomRepositoryAdapter.java
@@ -155,16 +155,10 @@ public class ChatRoomRepositoryAdapter implements GetChatRoomQuery, SaveChatRoom
             List<MessageJpaEntity> resultsMessages = results.stream()
                     .map(ChatRoomWithDetails::message)
                     .filter(Objects::nonNull)
-                    .map(messageJpaEntity -> {
-                                if (!userId.equals(messageJpaEntity.getSenderId())) {
-                                    messageJpaEntity.setReadStatus(true);
-                                }
-                                return messageJpaEntity;
-                            }
-                    )
                     .distinct()
                     .toList();
-            messages = messageRepository.saveAll(resultsMessages).stream().map(MessageJpaEntity::toModel).toList();
+            
+            messages = resultsMessages.stream().map(MessageJpaEntity::toModel).toList();
             chatRoom.removeParticipant(userId);
         }else{
             messages = results.stream()

--- a/chat-service/src/main/java/org/kiru/chat/adapter/out/persistence/UserJoinChatRoomRepository.java
+++ b/chat-service/src/main/java/org/kiru/chat/adapter/out/persistence/UserJoinChatRoomRepository.java
@@ -1,7 +1,6 @@
 package org.kiru.chat.adapter.out.persistence;
 
-import java.util.List;
-import java.util.Optional;
+import jakarta.persistence.QueryHint;
 import org.kiru.chat.adapter.in.web.res.AdminUserResponse;
 import org.kiru.chat.adapter.out.persistence.dto.ChatRoomProjection;
 import org.kiru.core.chat.userchatroom.entity.UserJoinChatRoom;
@@ -9,6 +8,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+
+import java.util.List;
+import java.util.Optional;
 
 
 public interface UserJoinChatRoomRepository extends JpaRepository<UserJoinChatRoom, Long> {
@@ -16,6 +19,10 @@ public interface UserJoinChatRoomRepository extends JpaRepository<UserJoinChatRo
     @Query("SELECT u.userId FROM UserJoinChatRoom u WHERE u.chatRoomId = :chatRoomId AND u.userId <> :senderId")
     List<Long> findOtherParticipantIds(Long chatRoomId, Long senderId);
 
+    @QueryHints(value = {
+            @QueryHint(name = "org.hibernate.cacheable", value = "false"),
+            @QueryHint(name = "jakarta.persistence.query.timeout", value = "5000")
+    })
     @Query("SELECT cr as chatRoom, " +
             "COUNT(CASE WHEN m.readStatus = false AND m.senderId <> :userId THEN m.id END) AS unreadMessageCount, " +
             "(SELECT m1.content"

--- a/core/src/main/java/org/kiru/core/chat/message/domain/Message.java
+++ b/core/src/main/java/org/kiru/core/chat/message/domain/Message.java
@@ -36,6 +36,10 @@ public class Message {
         this.chatRoomId = chatRoomId;
     }
 
+    public void setReadStatus(Boolean readStatus) {
+        this.readStatus = readStatus;
+    }
+
     public static Message of(Long id, String content, Long senderId, LocalDateTime createdAt, Long chatRoomId,Long sendedId, boolean readStatus) {
         return Message.builder()
                 .id(id)


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- fix/#194

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 채팅 메시지의 읽음 상태 처리 로직이 개선되어, 상대방이 실제 채팅방에 있을 때에만 메시지가 읽음으로 표시됩니다.
  - 채팅방 입장 관련 데이터 조회 성능이 최적화되어, 보다 원활하고 빠른 채팅 경험을 제공합니다.
  - 메시지의 읽음 상태를 수정할 수 있는 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->