### PR TITLE
Fix [#180] 사용자 추천 목록 조회 시 중복 제거

### DIFF
--- a/user-service/src/main/java/org/kiru/user/user/repository/UserRepository.java
+++ b/user-service/src/main/java/org/kiru/user/user/repository/UserRepository.java
@@ -84,7 +84,7 @@ public interface UserRepository extends JpaRepository<UserJpaEntity,Long> {
             GROUP BY up.user_id
         ),
         liked_me AS (
-            SELECT user_id
+            SELECT DISTINCT user_id
             FROM user_like
             WHERE liked_user_id = :userId AND like_status = 'LIKE'
         ),


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#180

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
사용자 추천 목록 조회 시 나를 좋아요한 유저에서 중복 제거를 추가했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #이슈번호

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 추천 목록에서 중복된 사용자 노출 문제를 해결하여, 이제 고유한 사용자만 추천됩니다. 이 개선으로 추천 기능의 신뢰성과 사용자 경험이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->