### PR TITLE
fix [#199] 좋아요 데이터 조회 시 가장 최근 데이터 한 개를 사용하도록 수정

### DIFF
--- a/user-service/src/main/java/org/kiru/user/userlike/repository/UserLikeJpaRepository.java
+++ b/user-service/src/main/java/org/kiru/user/userlike/repository/UserLikeJpaRepository.java
@@ -15,14 +15,14 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserLikeJpaRepository extends JpaRepository<UserLikeJpaEntity, Long>,  UserLikeRepository<UserLikeJpaEntity,Long>  {
-    Optional<UserLikeJpaEntity> findByUserIdAndLikedUserId(Long userId, Long likedUserId);
+    @Query("SELECT ul FROM UserLikeJpaEntity ul WHERE ul.userId = :userId AND ul.likedUserId = :likedUserId ORDER BY ul.updateAt DESC LIMIT 1")
+    Optional<UserLikeJpaEntity> findByUserIdAndLikedUserId(@Param("userId") Long userId, @Param("likedUserId") Long likedUserId);
 
     @Query("SELECT ul.userId FROM UserLikeJpaEntity ul WHERE ul.likedUserId = :likedUserId AND ul.isMatched = false GROUP BY ul.userId ORDER BY COUNT(ul.likedUserId) DESC")
     @QueryHints(value = {
             @QueryHint(name = "org.hibernate.readOnly", value = "true"),
             @QueryHint(name = "org.hibernate.fetchSize", value = "150"),
             @QueryHint(name = "jakarta.persistence.query.timeout", value = "5000")
-
     })
     List<Long> findAllLikeMeUserIdAndNotMatchedByLikedUserId(@Param("likedUserId") Long likedUserId, Pageable pageable);
 
@@ -51,7 +51,7 @@ public interface UserLikeJpaRepository extends JpaRepository<UserLikeJpaEntity, 
     })
     List<Long> findAllLikedUserIdByUserIdAndLikeStatus(@Param("userId") Long userId, @Param("status") LikeStatus likeStatus);
 
-    @Query("SELECT ul FROM UserLikeJpaEntity ul WHERE ul.userId = :likedUserId AND ul.likedUserId = :userId AND ul.likeStatus = :status")
+    @Query("SELECT ul FROM UserLikeJpaEntity ul WHERE ul.userId = :likedUserId AND ul.likedUserId = :userId AND ul.likeStatus = :status ORDER BY ul.updateAt DESC LIMIT 1")
     UserLikeJpaEntity findOppositeLike(@Param("likedUserId") Long likedUserId, @Param("userId") Long userId, @Param("status") LikeStatus status);
 
     @Query("SELECT ul.userId FROM UserLikeJpaEntity ul WHERE ul.likeStatus = 'LIKE' GROUP BY ul.userId ORDER BY COUNT(ul.likedUserId) DESC")


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#199

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

좋아요 데이터 조회 시 가장 최근 데이터 한 개를 사용하도록 수정

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 사용자 좋아요 기능이 항상 최신 업데이트 정보를 반영하도록 개선되었습니다.  
    이제 최신 상호작용 데이터가 일관되게 확인되어 서비스 이용 중 데이터의 정확도가 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->