### PR TITLE
Fix [#203] 사용자 추천 목록 포트폴리오id 별로 분리되는 이슈 해결

### DIFF
--- a/user-service/src/main/java/org/kiru/user/portfolio/repository/UserPortfolioRepository.java
+++ b/user-service/src/main/java/org/kiru/user/portfolio/repository/UserPortfolioRepository.java
@@ -7,6 +7,7 @@ import org.kiru.user.portfolio.adapter.dto.UserPortfolioProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -27,24 +28,24 @@ public interface UserPortfolioRepository extends JpaRepository<UserPortfolioImg,
     })
     List<UserPortfolioImg> findAllByUserIdInWithItemUrlMinSequence(List<Long> userIds);
 
-    @Query("""
+    @Query(value = """
     SELECT 
-        MIN(upi.portfolioId) as portfolioId,
-        upi.userId as userId,
-        upi.userName as username,
-        STRING_AGG(upi.portfolioImageUrl,',') as portfolioImageUrl
+        MIN(upi.portfolio_id) AS portfolioId,
+        upi.user_id AS userId,
+        upi.username AS username,
+        STRING_AGG(upi.portfolio_image_url, ',' ORDER BY upi.sequence) AS portfolioImageUrl
     FROM 
-       UserPortfolioImg upi
+        user_portfolio_imgs upi
     WHERE 
-        upi.userId IN :userIds
+        upi.user_id IN (:userIds)
     GROUP BY 
-         upi.userId, upi.userName
-    """)
+        upi.user_id, upi.username
+    """, nativeQuery = true)
     @QueryHints(value = {
             @QueryHint(name = "org.hibernate.readOnly", value = "true"),
             @QueryHint(name = "org.hibernate.fetchSize", value = "150"),
             @QueryHint(name = "jakarta.persistence.query.timeout", value = "5000")
 
     })
-    List<UserPortfolioProjection> findAllPortfoliosByUserIds(List<Long> userIds);
+    List<UserPortfolioProjection> findAllPortfoliosByUserIds(@Param("userIds") List<Long> userIds);
 }

--- a/user-service/src/main/java/org/kiru/user/portfolio/repository/UserPortfolioRepository.java
+++ b/user-service/src/main/java/org/kiru/user/portfolio/repository/UserPortfolioRepository.java
@@ -29,7 +29,7 @@ public interface UserPortfolioRepository extends JpaRepository<UserPortfolioImg,
 
     @Query("""
     SELECT 
-        upi.portfolioId as portfolioId,
+        MIN(upi.portfolioId) as portfolioId,
         upi.userId as userId,
         upi.userName as username,
         STRING_AGG(upi.portfolioImageUrl,',') as portfolioImageUrl
@@ -38,7 +38,7 @@ public interface UserPortfolioRepository extends JpaRepository<UserPortfolioImg,
     WHERE 
         upi.userId IN :userIds
     GROUP BY 
-         upi.userId, upi.userName, upi.portfolioId
+         upi.userId, upi.userName
     """)
     @QueryHints(value = {
             @QueryHint(name = "org.hibernate.readOnly", value = "true"),

--- a/user-service/src/main/java/org/kiru/user/user/repository/UserRepository.java
+++ b/user-service/src/main/java/org/kiru/user/user/repository/UserRepository.java
@@ -108,6 +108,7 @@ public interface UserRepository extends JpaRepository<UserJpaEntity,Long> {
         LEFT JOIN disliked_users du ON u.id = du.user_id
         WHERE u.id != :userId
           AND u.id NOT IN (SELECT user_id FROM excluded_users)
+          AND u.deleted = false
         ORDER BY
             CASE WHEN du.user_id IS NULL THEN 0 ELSE 1 END ASC,
             COALESCE(pm.purpose_match_count, 0) DESC,


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- fix/#203

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- Home: 사용자 추천 목록 포트폴리오이미지 시퀀스 순서 정렬
- Home: 사용자 추천 목록 포트폴리오id 별로 분리되는 이슈 해결
- Home: 탈퇴한 회원 (deleted = true)도 추천되는 이슈 해결

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

이번 릴리스에서는 사용자 포트폴리오와 추천 사용자 관련 기능이 개선되었습니다. 포트폴리오 정보는 각 사용자별 대표 항목으로 통합되어 깔끔하게 표시되며, 추천 사용자 목록은 활성 사용자만을 대상으로 제공되어 보다 정확한 결과를 기대할 수 있습니다.

- **New Features**
	- 포트폴리오 정보가 각 사용자별로 최소 항목으로 통합되어 표시됩니다.
	- 추천 사용자 목록에서 삭제된 사용자가 제외되어 활성 사용자만 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->