### PR TITLE
Feat [#216] AccessToken 문제 있으면 401error 전송 

### DIFF
--- a/gateway-service/src/main/java/org/kiru/gateway/adapter/UserAdapter.java
+++ b/gateway-service/src/main/java/org/kiru/gateway/adapter/UserAdapter.java
@@ -2,6 +2,7 @@ package org.kiru.gateway.adapter;
 
 import lombok.RequiredArgsConstructor;
 import org.kiru.core.exception.EntityNotFoundException;
+import org.kiru.core.exception.UnauthorizedException;
 import org.kiru.core.exception.code.FailureCode;
 import org.kiru.gateway.common.UserGatewayRepository;
 import org.kiru.gateway.jwt.JwtValidStatusDto;
@@ -21,7 +22,7 @@ public class UserAdapter implements GetUserPort {
         return userGatewayRepository.findByIdAndEmail(userId, email)
                 .map(JwtValidStatusDto::of)
                 .flatMap(dto -> redisTemplate.opsForValue().set(token, dto).thenReturn(dto))
-                .switchIfEmpty(Mono.defer(() -> Mono.error(new EntityNotFoundException(FailureCode.USER_NOT_FOUND))));
+                .switchIfEmpty(Mono.defer(() -> Mono.error(new UnauthorizedException(FailureCode.UNAUTHORIZED))));
     }
 
     @Override

--- a/gateway-service/src/main/java/org/kiru/gateway/filter/AuthenticationFilter.java
+++ b/gateway-service/src/main/java/org/kiru/gateway/filter/AuthenticationFilter.java
@@ -2,6 +2,8 @@ package org.kiru.gateway.filter;
 
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.kiru.core.exception.UnauthorizedException;
+import org.kiru.core.exception.code.FailureCode;
 import org.kiru.gateway.filter.AuthenticationFilter.Config;
 import org.kiru.gateway.jwt.JwtUtils;
 import org.kiru.gateway.jwt.JwtValidationType;
@@ -51,8 +53,7 @@ public class AuthenticationFilter extends AbstractGatewayFilterFactory<Config> {
                                             .request(modifiedRequest)
                                             .build());
                                 }
-                                return Mono.error(new RuntimeException(
-                                        "Invalid JWT token: " + token + " : " + jwtValidResponse.status()));
+                                return Mono.error(UnauthorizedException::new);
                             });
                 }
                 exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#216

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #216 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 사용자 정보 조회 시, 존재하지 않는 사용자에 대한 처리 대신 인증 실패로 명확하게 오류가 전달됩니다.
	- 유효하지 않은 인증 토큰 처리 로직이 개선되어, 일관된 인증 오류 응답이 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->