### PR TITLE
fix [#221] 삭제 일정 추가

### DIFF
--- a/core/src/main/java/org/kiru/core/user/common/BaseTimeEntity.java
+++ b/core/src/main/java/org/kiru/core/user/common/BaseTimeEntity.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -26,6 +27,11 @@ public abstract class BaseTimeEntity {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     public void setUpdatedAt() { this.updatedAt = LocalDateTime.now(); }
+
+    public void setDeletedAt() { this.deletedAt = LocalDateTime.now(); }
 }
 

--- a/core/src/main/java/org/kiru/core/user/user/entity/UserJpaEntity.java
+++ b/core/src/main/java/org/kiru/core/user/user/entity/UserJpaEntity.java
@@ -18,7 +18,7 @@ import org.kiru.core.user.user.domain.User;
 @Table(name = "users",
         indexes = {@Index(name = "idx_username", columnList = "username"),
                 @Index(name = "idx_email", columnList = "email")})
-@SQLDelete(sql = "UPDATE users SET deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE users SET deleted = true, deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted = false")
 public class UserJpaEntity extends BaseTimeEntity {
     @Id


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- fix/#221

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- deleted_at 추가

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
배포 후 서버에 SQL 업데이트 필요함.
```SQL
ALTER TABLE users ADD COLUMN deleted_at TIMESTAMP;
```
## 📟 관련 이슈
- Resolved: #이슈번호

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 삭제된 데이터의 타임스탬프를 기록하여, 삭제 시점에 대한 추적 및 감사 기능이 강화되었습니다.
  - 사용자 데이터 삭제 시, 삭제 시간 정보가 함께 기록되어 데이터 이력 관리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->