### PR TITLE
Fix [#232] 매치/디테일에서 주는 이미지 개수 정합성 이슈

### DIFF
--- a/user-service/src/main/java/org/kiru/user/portfolio/repository/UserPortfolioRepository.java
+++ b/user-service/src/main/java/org/kiru/user/portfolio/repository/UserPortfolioRepository.java
@@ -12,7 +12,10 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserPortfolioRepository extends JpaRepository<UserPortfolioImg, Long> {
-    @Query("SELECT upi FROM UserPortfolioImg upi WHERE upi.userId = :userId ORDER BY upi.sequence LIMIT 10")
+    @Query(
+        value = "SELECT * FROM user_portfolio_imgs WHERE user_id = :userId ORDER BY sequence LIMIT 10",
+        nativeQuery = true
+    )
     List<UserPortfolioImg> findAllByUserId(Long userId);
 
     void deleteAllByUserId(Long userId);
@@ -28,18 +31,37 @@ public interface UserPortfolioRepository extends JpaRepository<UserPortfolioImg,
     })
     List<UserPortfolioImg> findAllByUserIdInWithItemUrlMinSequence(List<Long> userIds);
 
-    @Query(value = """
-    SELECT 
-        MIN(upi.portfolio_id) AS portfolioId,
-        upi.user_id AS userId,
-        upi.username AS username,
-        STRING_AGG(upi.portfolio_image_url, ',' ORDER BY upi.sequence) AS portfolioImageUrl
-    FROM 
-        user_portfolio_imgs upi
-    WHERE 
-        upi.user_id IN (:userIds)
-    GROUP BY 
-        upi.user_id, upi.username
+//    @Query(value = """
+//    SELECT
+//        MIN(upi.portfolio_id) AS portfolioId,
+//        upi.user_id AS userId,
+//        upi.username AS username,
+//        STRING_AGG(upi.portfolio_image_url, ',' ORDER BY upi.sequence) AS portfolioImageUrl
+//    FROM
+//        user_portfolio_imgs upi
+//    WHERE
+//        upi.user_id IN (:userIds)
+//    GROUP BY
+//        upi.user_id, upi.username
+//    """, nativeQuery = true)
+@Query(value = """
+    WITH ranked_imgs AS (
+        SELECT
+            upi.*,
+            ROW_NUMBER() OVER (PARTITION BY upi.user_id ORDER BY upi.sequence) AS rn
+        FROM user_portfolio_imgs upi
+        WHERE upi.user_id IN (:userIds)
+    ),
+    limited_imgs AS (
+        SELECT * FROM ranked_imgs WHERE rn <= 10
+    )
+    SELECT
+        MIN(portfolio_id) AS portfolioId,
+        user_id AS userId,
+        username AS username,
+        STRING_AGG(portfolio_image_url, ',' ORDER BY sequence) AS portfolioImageUrl
+    FROM limited_imgs
+    GROUP BY user_id, username
     """, nativeQuery = true)
     @QueryHints(value = {
             @QueryHint(name = "org.hibernate.readOnly", value = "true"),


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- fix/#이슈번호
232👷 **작업한 내용**

<!-- 작업한 내용을 적어주세요. -->
매치/디테일에서 주는 이미지 개수 정합성 이슈

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 사용자별 포트폴리오 이미지 조회 시 최대 10개까지만 표시되도록 쿼리가 개선되었습니다.  
  - 여러 사용자의 포트폴리오 이미지를 불러올 때도 각 사용자별로 최대 10개의 이미지까지만 집계되어 보여집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->