### PR TITLE
Feat [#251] 스와이프 좋아요 횟수 제한 기능 구현

### DIFF
--- a/core/src/main/java/org/kiru/core/exception/code/FailureCode.java
+++ b/core/src/main/java/org/kiru/core/exception/code/FailureCode.java
@@ -93,6 +93,11 @@ public enum FailureCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "e4093", "이미 존재하는 이메일입니다."),
 
     /**
+     * 429 Too Many Request
+     */
+    LIKE_TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "e4290", "일일 좋아요 횟수를 초과했습니다."),
+
+    /**
      * 500 Internal Server Error
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "e5000", "서버 내부 오류입니다."),

--- a/user-service/src/main/java/org/kiru/user/userlike/controller/UserLikeController.java
+++ b/user-service/src/main/java/org/kiru/user/userlike/controller/UserLikeController.java
@@ -7,14 +7,12 @@ import org.kiru.core.exception.BadRequestException;
 import org.kiru.core.exception.code.FailureCode;
 import org.kiru.user.auth.argumentresolve.UserId;
 import org.kiru.user.userlike.dto.req.LikeRequest;
+import org.kiru.user.userlike.dto.res.LikeLimitResponse;
 import org.kiru.user.userlike.dto.res.LikeResponse;
 import org.kiru.user.userlike.service.UserLikeService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -22,6 +20,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class UserLikeController {
     private final UserLikeService userLikeService;
+
+    @GetMapping
+    public ResponseEntity<LikeLimitResponse> getLikeLimit(@UserId Long userId) {
+        LikeLimitResponse likeLimitResponse = userLikeService.getLikeLimit(userId);
+        return ResponseEntity.status(HttpStatus.OK).body(likeLimitResponse);
+    }
 
     @PostMapping
     public ResponseEntity<LikeResponse> sendLikeOrDislike(

--- a/user-service/src/main/java/org/kiru/user/userlike/dto/res/LikeLimitResponse.java
+++ b/user-service/src/main/java/org/kiru/user/userlike/dto/res/LikeLimitResponse.java
@@ -1,0 +1,18 @@
+package org.kiru.user.userlike.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class LikeLimitResponse {
+    int likeLimit;
+    int likeCount;
+
+    public static LikeLimitResponse of(int likeLimit, int likeCount) {
+        return LikeLimitResponse.builder()
+                .likeLimit(likeLimit)
+                .likeCount(likeCount)
+                .build();
+    }
+}

--- a/user-service/src/main/java/org/kiru/user/userlike/dto/res/LikeResponse.java
+++ b/user-service/src/main/java/org/kiru/user/userlike/dto/res/LikeResponse.java
@@ -12,11 +12,14 @@ public class LikeResponse {
     boolean isMatched;
     List<UserPortfolioResDto> userPortfolios;
     Long chatRoomId;
+    int likeCount;
 
-    public static LikeResponse of(boolean isMatched, List<UserPortfolioResDto> userPortfolios, Long chatRoomId) {
+    public static LikeResponse of(boolean isMatched, List<UserPortfolioResDto> userPortfolios, Long chatRoomId, int likeCount) {
         return LikeResponse.builder()
                 .isMatched(isMatched)
                 .userPortfolios(userPortfolios)
-                .chatRoomId(chatRoomId).build();
+                .chatRoomId(chatRoomId)
+                .likeCount(likeCount)
+                .build();
     }
 }

--- a/user-service/src/main/java/org/kiru/user/userlike/service/UserLikeService.java
+++ b/user-service/src/main/java/org/kiru/user/userlike/service/UserLikeService.java
@@ -1,10 +1,17 @@
 package org.kiru.user.userlike.service;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 import org.kiru.core.chat.chatroom.domain.ChatRoomType;
+import org.kiru.core.exception.BadRequestException;
+import org.kiru.core.exception.code.FailureCode;
 import org.kiru.core.user.userlike.domain.LikeStatus;
 import org.kiru.user.portfolio.dto.res.UserPortfolioResDto;
 import org.kiru.user.user.api.ChatApiClient;
@@ -14,6 +21,7 @@ import org.kiru.user.userlike.dto.res.LikeResponse;
 import org.kiru.user.userlike.service.out.GetMatchedUserPortfolioQuery;
 import org.kiru.user.userlike.service.out.SendLikeOrDislikeUseCase;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import lombok.extern.slf4j.Slf4j;
@@ -26,22 +34,28 @@ public class UserLikeService {
     private final ChatApiClient chatRoomCreateApiClient;
     private final MatchNotificationService matchNotificationService;
     private final Executor virtualThreadExecutor;
+    private final RedisTemplate<String, String> redisTemplateForOne;
 
     public UserLikeService(
             @Qualifier("userLikeJpaAdapter") SendLikeOrDislikeUseCase sendLikeOrDislikeUseCase,
             GetMatchedUserPortfolioQuery getMatchedUserPortfolioQuery,
             ChatApiClient chatRoomCreateApiClient,
             MatchNotificationService matchNotificationService,
-            Executor virtualThreadExecutor) {
+            Executor virtualThreadExecutor,
+            RedisTemplate<String, String> redisTemplateForOne) {
         this.sendLikeOrDislikeUseCase = sendLikeOrDislikeUseCase;
         this.getMatchedUserPortfolioQuery = getMatchedUserPortfolioQuery;
         this.chatRoomCreateApiClient = chatRoomCreateApiClient;
         this.matchNotificationService = matchNotificationService;
         this.virtualThreadExecutor = virtualThreadExecutor;
+        this.redisTemplateForOne = redisTemplateForOne;
 
     }
 
     public LikeResponse sendLikeOrDislike(Long userId, Long likedUserId, LikeStatus status) {
+        // 좋아요 횟수 체크
+        int likeCount = increaseLikeCount(userId, status);
+
         boolean isMatched = sendLikeOrDislikeUseCase.sendLikeOrDislike(userId, likedUserId, status).isMatched();
         
         // 좋아요 생성 시 푸시 알림 전송 (좋아요를 받은 사람에게만)
@@ -59,7 +73,6 @@ public class UserLikeService {
 //                }
 //            }, virtualThreadExecutor);
 //        }
-
         if (isMatched) {
             log.info("User matched with userId: {} and likedUserId: {}", userId, likedUserId);
 
@@ -77,9 +90,41 @@ public class UserLikeService {
                 virtualThreadExecutor
             );
             return CompletableFuture.allOf(portfolioFuture, chatRoomIdFuture).thenApplyAsync(v -> LikeResponse.of(
-                    true, portfolioFuture.join(), chatRoomIdFuture.join().getChatRoomId()
+                    true, portfolioFuture.join(), chatRoomIdFuture.join().getChatRoomId(), likeCount
             )).join();
         }
-        return LikeResponse.of(false, null, null);
+        return LikeResponse.of(false, null, null, likeCount);
+    }
+
+    private int increaseLikeCount(Long userId, LikeStatus status) {
+        ZoneId zoneKST = ZoneId.of("Asia/Seoul");
+        LocalDateTime now = LocalDateTime.now(zoneKST);
+        String today = now.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String key = "likeCount:" + userId + ":" + today;
+
+        String likeCountStr = redisTemplateForOne.opsForValue().get(key);
+        log.debug("{} = {}", key, likeCountStr);
+
+        int likeCount = (likeCountStr != null) ? Integer.parseInt(likeCountStr) : 0;
+        
+        if (status == LikeStatus.LIKE) {
+            if (likeCount >= 5) {
+                log.debug("좋아요 횟수 제한을 초과했음.");
+                throw new BadRequestException(FailureCode.LIKE_TOO_MANY_REQUESTS);
+            }
+            
+            if (likeCountStr == null) {
+                log.debug("레디스 데이터 생성");
+                long secondsUntilEndOfDay = Duration.between(
+                        now,
+                        now.toLocalDate().plusDays(1).atStartOfDay(zoneKST)
+                ).getSeconds();
+                redisTemplateForOne.expire(key, secondsUntilEndOfDay, TimeUnit.SECONDS);
+            }
+            
+            likeCount += 1;
+            redisTemplateForOne.opsForValue().set(key, String.valueOf(likeCount));
+        }
+        return likeCount;
     }
 }

--- a/user-service/src/main/java/org/kiru/user/userlike/service/UserLikeService.java
+++ b/user-service/src/main/java/org/kiru/user/userlike/service/UserLikeService.java
@@ -53,7 +53,7 @@ public class UserLikeService {
     }
 
     public LikeLimitResponse getLikeLimit(Long userId) {
-        int likeLimit = 3;
+        int likeLimit = 50;
         int likeCount = getLikeCount(userId);
         return LikeLimitResponse.of(likeLimit, likeCount);
     }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feat/#251

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 좋아요 횟수와 제한 정보를 조회하는 api를 구현했습니다
- like/dislike 요청에 대한 반환값에 likeCount를 추가했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
iOS의 251 PR과 함께 반영되어야합니다.
https://github.com/wakawaka-CONTACTO/CONTACTO-iOS/pull/256

## 📟 관련 이슈
- Resolved: #251