### PR TITLE
chore [#273] discovery 이미지 생성시 Dockerfile_discovery사용

### DIFF
--- a/.github/workflows/discovery-cd.yml
+++ b/.github/workflows/discovery-cd.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Docker Image Build and Push
         run: |
-          docker build --build-arg SERVICE_NAME=discovery -t ${{ secrets.DOCKER_REPOSITORY }}/discovery-image .
+          docker build --build-arg SERVICE_NAME=discovery -f Dockerfile_discovery -t ${{ secrets.DOCKER_REPOSITORY }}/discovery-image .
           docker push ${{ secrets.DOCKER_REPOSITORY }}/discovery-image
 
       - name: Deploy Discovery Service via SSH

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 RUN echo ${SERVICE_NAME}
 COPY ${SERVICE_NAME}/build/libs/*.jar app.jar
 ENV SPRING_PROFILES_ACTIVE=dev
+
 # Stage 3: 최종 이미지 (최소화된 JRE와 애플리케이션 포함)
 FROM alpine:3.18.4
 ENV JAVA_HOME=/custom-jre
@@ -23,4 +24,8 @@ ENV PATH="$JAVA_HOME/bin:$PATH"
 WORKDIR /app
 COPY --from=builder-jre /custom-jre $JAVA_HOME
 COPY --from=builder /app/app.jar app.jar
-ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "-Dspring.profiles.active=dev", "app.jar"]
+
+# Datadog Java Agent 다운로드
+RUN wget -O dd-java-agent.jar https://dtdg.co/latest-java-tracer
+
+ENTRYPOINT ["java", "-javaagent:/app/dd-java-agent.jar", "-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=dev", "-jar", "app.jar"]

--- a/Dockerfile_discovery
+++ b/Dockerfile_discovery
@@ -16,7 +16,6 @@ WORKDIR /app
 RUN echo ${SERVICE_NAME}
 COPY ${SERVICE_NAME}/build/libs/*.jar app.jar
 ENV SPRING_PROFILES_ACTIVE=dev
-
 # Stage 3: 최종 이미지 (최소화된 JRE와 애플리케이션 포함)
 FROM alpine:3.18.4
 ENV JAVA_HOME=/custom-jre
@@ -24,8 +23,4 @@ ENV PATH="$JAVA_HOME/bin:$PATH"
 WORKDIR /app
 COPY --from=builder-jre /custom-jre $JAVA_HOME
 COPY --from=builder /app/app.jar app.jar
-
-# Datadog Java Agent 다운로드
-RUN wget -O dd-java-agent.jar https://dtdg.co/latest-java-tracer
-
-ENTRYPOINT ["java", "-javaagent:/app/dd-java-agent.jar", "-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=dev", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "-Dspring.profiles.active=dev", "app.jar"]


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- chore/#273

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Discovery 서비스의 배포 워크플로우에서 Dockerfile 지정 방식을 명확히 수정했습니다.
- **Refactor**
  - 메인 Dockerfile에 Datadog Java Agent가 포함되어 애플리케이션 실행 시 적용됩니다.
  - Discovery 서비스 전용 Dockerfile에서는 Datadog Java Agent 관련 설정이 제거되어 더욱 단순화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->