### PR TITLE
feat [#278] 탈퇴한 유저와의 채팅방 No Name 처리

### DIFF
--- a/core/src/main/java/org/kiru/core/chat/chatroom/domain/ChatRoom.java
+++ b/core/src/main/java/org/kiru/core/chat/chatroom/domain/ChatRoom.java
@@ -99,6 +99,12 @@ public class ChatRoom {
     }
 
     @JsonIgnore
+    public void setThumbnailAndRoomTitle(String itemUrl, String username) {
+        this.chatRoomThumbnail = itemUrl;
+        this.title = username;
+    }
+
+    @JsonIgnore
     public static List<Long> getAllParticipantIds(List<ChatRoom> chatRooms) {
         return chatRooms.stream()
                 .flatMap(chatRoom -> Objects.requireNonNull(chatRoom.getParticipants()).stream())

--- a/user-service/src/main/java/org/kiru/user/user/service/UserService.java
+++ b/user-service/src/main/java/org/kiru/user/user/service/UserService.java
@@ -1,12 +1,9 @@
 package org.kiru.user.user.service;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -71,10 +68,35 @@ public class UserService implements GetUserMainPageUseCase {
         CompletableFuture<Map<Long, UserPortfolioItem>> userPortfolioImgMapFuture = allParticipantIdsFuture.thenApplyAsync(
                 UserPortfolio::getUserIdAndUserPortfolioItemMap, executor
         );
-        return chatRoomsFuture.thenCombineAsync(userPortfolioImgMapFuture, (chatRooms, userPortfolioImgMap) -> {
-            chatRooms.getContent().forEach(chatRoom -> chatRoom.setThumbnailAndRoomTitle(userPortfolioImgMap));
-            return chatRooms;
-            }, executor).join();
+
+        CompletableFuture<Map<Long, Boolean>> activeUsersFuture = chatRoomsFuture.thenApplyAsync(
+                chatRooms -> {
+                    Set<Long> participantIds = new HashSet<>(ChatRoom.getAllParticipantIds(chatRooms.getContent()));
+                    return participantIds.stream().collect(Collectors.toMap(id -> id, id -> userRepository.existsById(id)));
+                }, executor);
+
+        return chatRoomsFuture.thenCombineAsync(
+                CompletableFuture.allOf(userPortfolioImgMapFuture, activeUsersFuture)
+                        .thenApply(v -> Map.of(
+                                "portfolioMap", userPortfolioImgMapFuture.join(),
+                                "activeUsers", activeUsersFuture.join()
+                        )),
+                (chatRooms, maps) -> {
+                    Map<Long, UserPortfolioItem> portfolioMap = (Map<Long, UserPortfolioItem>) maps.get("portfolioMap");
+                    Map<Long, Boolean> activeUsers = (Map<Long, Boolean>) maps.get("activeUsers");
+                    
+                    chatRooms.getContent().forEach(chatRoom -> {
+                        Optional<UserPortfolioItem> userPortfolioItem = chatRoom.getParticipants().stream()
+                                .filter(activeUsers::get).map(portfolioMap::get).filter(Objects::nonNull)
+                                .min(Comparator.comparingInt(UserPortfolioItem::getSequence));
+                        if (userPortfolioItem.isPresent()) {
+                            chatRoom.setThumbnailAndRoomTitle(userPortfolioItem.get());
+                        } else {
+                            chatRoom.setThumbnailAndRoomTitle("", "No Name");
+                        }
+                    });
+                    return chatRooms;
+                }, executor).join();
         }
     }
 

--- a/user-service/src/main/java/org/kiru/user/user/service/UserService.java
+++ b/user-service/src/main/java/org/kiru/user/user/service/UserService.java
@@ -87,7 +87,9 @@ public class UserService implements GetUserMainPageUseCase {
                     
                     chatRooms.getContent().forEach(chatRoom -> {
                         Optional<UserPortfolioItem> userPortfolioItem = chatRoom.getParticipants().stream()
-                                .filter(activeUsers::get).map(portfolioMap::get).filter(Objects::nonNull)
+                                .filter(id -> Boolean.TRUE.equals(activeUsers.getOrDefault(id, false)))
+                                .map(portfolioMap::get)
+                                .filter(Objects::nonNull)
                                 .min(Comparator.comparingInt(UserPortfolioItem::getSequence));
                         if (userPortfolioItem.isPresent()) {
                             chatRoom.setThumbnailAndRoomTitle(userPortfolioItem.get());


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feat/#278

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

탈퇴한 유저와의 채팅방 No Name 처리
- 채팅방 썸네일 "" 빈값 처리
- 채팅방 타이틀 No Name 처리

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

iOS에서 보이는 내용

![Simulator Screenshot - iPhone 16e - 2025-05-07 at 18 19 55](https://github.com/user-attachments/assets/b8c590ed-a938-470a-87ec-940703cf2c7f)


## 📟 관련 이슈
- Resolved: #278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 채팅방의 썸네일과 제목을 직접 문자열로 설정하는 기능이 추가되었습니다.

- **버그 수정**
  - 채팅방 목록에서 비활성화된 사용자를 제외하고, 활성화된 참가자 중 포트폴리오 정보가 있는 사용자의 정보를 우선적으로 표시하도록 개선되었습니다.
  - 활성화된 참가자가 없거나 포트폴리오 정보가 없는 경우, 기본 썸네일과 "No Name"이 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->